### PR TITLE
Add the reporter's sub to the record.

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -50,6 +50,7 @@ func (api *API) blockPOST(w http.ResponseWriter, r *http.Request, _ httprouter.P
 		Tags:           body.Tags,
 		TimestampAdded: time.Now().UTC(),
 	}
+	skylink.Reporter.Sub = r.Form.Get("sub")
 	api.staticLogger.Tracef("blockPOST will block skylink %s", skylink)
 	err = api.staticDB.BlockedSkylinkCreate(r.Context(), skylink)
 	if errors.Contains(err, database.ErrSkylinkExists) {

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -22,5 +22,6 @@ type BlockedSkylink struct {
 type Reporter struct {
 	Name         string `bson:"name" json:"name"`
 	Email        string `bson:"email" json:"email"`
-	OtherContact string `bson:"other_contact" json:"otherContact"` // TODO Cap at 255 chars?
+	OtherContact string `bson:"other_contact" json:"otherContact"`
+	Sub          string `bson:"sub,omitempty" json:"sub,omitempty"`
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Add the user's unique sub to the `Reporter` object, so we can easily cross-reference reporters with `accounts`'s database. This approach has the advantage of maintaining the relationship even after the reporter changes their email address.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
