### PR TITLE
Mark authenticated vs unauthenticated reports

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"regexp"
 	"time"
 
@@ -61,7 +62,19 @@ func (api *API) blockPOST(w http.ResponseWriter, r *http.Request, _ httprouter.P
 		Tags:           body.Tags,
 		TimestampAdded: time.Now().UTC(),
 	}
-	skylink.Reporter.Sub = r.Form.Get("sub")
+	// Avoid nullpointer.
+	if r.Form == nil {
+		r.Form = url.Values{}
+	}
+	sub := r.Form.Get("sub")
+	if sub == "" {
+		// No sub. Maybe we didn't try to fetch it? Try now. Don't log errors.
+		u, err := UserFromReq(r, api.staticLogger)
+		if err == nil {
+			sub = u.Sub
+		}
+	}
+	skylink.Reporter.Sub = sub
 	api.staticLogger.Tracef("blockPOST will block skylink %s", skylink)
 	err = api.staticDB.BlockedSkylinkCreate(r.Context(), skylink)
 	if errors.Contains(err, database.ErrSkylinkExists) {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -75,6 +75,7 @@ func (api *API) blockPOST(w http.ResponseWriter, r *http.Request, _ httprouter.P
 		}
 	}
 	skylink.Reporter.Sub = sub
+	skylink.Reporter.Unauthenticated = sub == ""
 	api.staticLogger.Tracef("blockPOST will block skylink %s", skylink)
 	err = api.staticDB.BlockedSkylinkCreate(r.Context(), skylink)
 	if errors.Contains(err, database.ErrSkylinkExists) {

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -20,8 +20,9 @@ type BlockedSkylink struct {
 
 // Reporter is a person who reported that a given skylink should be blocked.
 type Reporter struct {
-	Name         string `bson:"name" json:"name"`
-	Email        string `bson:"email" json:"email"`
-	OtherContact string `bson:"other_contact" json:"otherContact"`
-	Sub          string `bson:"sub,omitempty" json:"sub,omitempty"`
+	Name            string `bson:"name" json:"name"`
+	Email           string `bson:"email" json:"email"`
+	OtherContact    string `bson:"other_contact" json:"otherContact"`
+	Sub             string `bson:"sub,omitempty" json:"sub,omitempty"`
+	Unauthenticated bool   `bson:"unauthenticated,omitempty" json:"unauthenticated,omitempty"`
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Bring back the check for user's data, even if it's not obligatory now. We will just mark authenticated vs unauthenticated reports.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
