### PR TITLE
Nginx cache purge

### DIFF
--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -30,14 +30,20 @@ const (
 var (
 	// NginxCachePurgerListPath is the path at which we can find the list where
 	// we want to add the skylinks which we want purged from nginx's cache.
-	// This value can be configured via the BLOCKER_NGINX_CACHE_PURGE_LIST
-	// environment variable.
+	//
+	// NOTE: this value can be configured via the BLOCKER_NGINX_CACHE_PURGE_LIST
+	// environment variable, however it is important that this path matches the
+	// path in the nginx purge script that is part of the cron.
 	NginxCachePurgerListPath = "/data/nginx/blocker/skylinks.txt"
 
 	// NginxCachePurgeLockPath is the path to the lock directory. The blocker
-	// writes to the list file while holding the lock to ensure the file isn't
-	// altered by the cron job that purges the nginx cache. // This value can be
-	// configured via the BLOCKER_NGINX_CACHE_PURGE_LOCK environment variable.
+	// acquires this lock before writing to the list file, essentially ensuring
+	// the purge script does not alter the file while the blocker API is writing
+	// to it.
+	//
+	// NOTE: this value can be configured via the BLOCKER_NGINX_CACHE_PURGE_LOCK
+	// environment variable, however it is important that this path matches the
+	// path in the nginx purge script that is part of the cron.
 	NginxCachePurgeLockPath = "/data/nginx/blocker/lock"
 
 	// skydTimeout is the timeout of the http calls to skyd in seconds
@@ -48,7 +54,7 @@ var (
 		build.Var{
 			Dev:      10 * time.Second,
 			Testing:  100 * time.Millisecond,
-			Standard: 30 * time.Minute,
+			Standard: time.Minute,
 		},
 	).(time.Duration)
 	// sleepOnErrStep defines the base step for sleeping after encountering an

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -295,7 +295,7 @@ func (bl *Blocker) writeToNginxCachePurger(sls []string) error {
 	}()
 
 	// open the nginx cache list file
-	f, err := os.OpenFile(NginxCachePurgerListPath, os.O_APPEND&os.O_CREATE, 0644)
+	f, err := os.OpenFile(NginxCachePurgerListPath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -135,8 +135,11 @@ func main() {
 	}
 
 	// Initialise and start the background scanner task.
-	if p := os.Getenv("BLOCKER_NGINX_CACHE_PURGE_LIST"); p != "" {
-		blocker.NginxCachePurgerListPath = p
+	if nginxList := os.Getenv("BLOCKER_NGINX_CACHE_PURGE_LIST"); nginxList != "" {
+		blocker.NginxCachePurgerListPath = nginxList
+	}
+	if nginxLock := os.Getenv("BLOCKER_NGINX_CACHE_PURGE_LOCK"); nginxLock != "" {
+		blocker.NginxCachePurgeLockPath = nginxLock
 	}
 	blockerThread, err := blocker.New(ctx, db, logger)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -135,6 +135,9 @@ func main() {
 	}
 
 	// Initialise and start the background scanner task.
+	if p := os.Getenv("BLOCKER_NGINX_CACHE_PURGE_LIST"); p != "" {
+		blocker.NginxCachePurgerListPath = p
+	}
 	blockerThread, err := blocker.New(ctx, db, logger)
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to instantiate blocker"))


### PR DESCRIPTION

# PULL REQUEST

## Overview

Add all skylinks being blocked to a file in nginx's container where another process will purge them from nginx's cache.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
