### PR TITLE
Nginx Block Skylink

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,14 @@ const (
 	// "API_PORT" environment variables.
 	defaultSkydPort = 9980
 
+	// defaultNginxHost is where we connect to nginx unless overwritten by
+	// "NGINX_HOST" environment variables.
+	defaultNginxHost = "10.10.10.30"
+
+	// defaultNginxPort is where we connect to nginx unless overwritten by
+	// "NGINX_PORT" environment variables.
+	defaultNginxPort = 8000
+
 	// defaultNginxCachePurgerListPath is the path at which we can find the list where
 	// we want to add the skylinks which we want purged from nginx's cache.
 	//
@@ -117,6 +125,15 @@ func main() {
 	if skydHostEnv := os.Getenv("API_HOST"); skydHostEnv != "" {
 		skydHost = skydHostEnv
 	}
+	nginxPort := defaultNginxPort
+	nginxPortEnv, err := strconv.Atoi(os.Getenv("NGINX_PORT"))
+	if err == nil && nginxPortEnv > 0 {
+		nginxPort = nginxPortEnv
+	}
+	nginxHost := defaultNginxHost
+	if nginxHostEnv := os.Getenv("NGINX_HOST"); nginxHostEnv != "" {
+		nginxHost = nginxHostEnv
+	}
 	skydAPIPassword := os.Getenv("SIA_API_PASSWORD")
 	if skydAPIPassword == "" {
 		log.Fatal(errors.New("SIA_API_PASSWORD is empty, exiting"))
@@ -141,7 +158,7 @@ func main() {
 	}
 
 	// Create a skyd API.
-	skydAPI, err := skyd.NewSkydAPI(skydHost, skydAPIPassword, skydPort, db, logger)
+	skydAPI, err := skyd.NewSkydAPI(nginxHost, nginxPort, skydHost, skydAPIPassword, skydPort, db, logger)
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to instantiate Skyd API"))
 	}

--- a/skyd/api.go
+++ b/skyd/api.go
@@ -70,7 +70,6 @@ func (skyd *SkydAPI) BlockSkylinks(sls []string) error {
 		return errors.AddContext(err, "failed to build request body")
 	}
 
-	// TODO: use environment variables to specify the nginx IP and PORT
 	url := fmt.Sprintf("http://%s:%d/skynet/blocklist?timeout=%s", skyd.staticNginxHost, skyd.staticNginxPort, skydTimeout)
 
 	skyd.staticLogger.Debugf("blockSkylinks: POST on %+s", url)

--- a/skyd/api.go
+++ b/skyd/api.go
@@ -64,7 +64,8 @@ func (skyd *SkydAPI) BlockSkylinks(sls []string) error {
 		return errors.AddContext(err, "failed to build request body")
 	}
 
-	url := fmt.Sprintf("http://%s:%d/skynet/blocklist?timeout=%s", skyd.staticSkydHost, skyd.staticSkydPort, skydTimeout)
+	// TODO: use environment variables to specify the nginx IP and PORT
+	url := fmt.Sprintf("http://10.10.10.30:8000/skynet/blocklist?timeout=%s", skydTimeout)
 
 	skyd.staticLogger.Debugf("blockSkylinks: POST on %+s", url)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBodyBytes))

--- a/skyd/api.go
+++ b/skyd/api.go
@@ -24,6 +24,9 @@ const (
 // SkydAPI is a helper struct that exposes some methods that allow making skyd
 // API calls used by both the API and the blocker
 type SkydAPI struct {
+	staticNginxHost string
+	staticNginxPort int
+
 	staticSkydHost        string
 	staticSkydPort        int
 	staticSkydAPIPassword string
@@ -33,7 +36,7 @@ type SkydAPI struct {
 }
 
 // NewSkydAPI creates a new Skyd API instance.
-func NewSkydAPI(skydHost, skydPassword string, skydPort int, db *database.DB, logger *logrus.Logger) (*SkydAPI, error) {
+func NewSkydAPI(nginxHost string, nginxPort int, skydHost, skydPassword string, skydPort int, db *database.DB, logger *logrus.Logger) (*SkydAPI, error) {
 	if db == nil {
 		return nil, errors.New("no DB provided")
 	}
@@ -42,6 +45,9 @@ func NewSkydAPI(skydHost, skydPassword string, skydPort int, db *database.DB, lo
 	}
 
 	return &SkydAPI{
+		staticNginxHost: nginxHost,
+		staticNginxPort: nginxPort,
+
 		staticSkydHost:        skydHost,
 		staticSkydPort:        skydPort,
 		staticSkydAPIPassword: skydPassword,
@@ -65,7 +71,7 @@ func (skyd *SkydAPI) BlockSkylinks(sls []string) error {
 	}
 
 	// TODO: use environment variables to specify the nginx IP and PORT
-	url := fmt.Sprintf("http://10.10.10.30:8000/skynet/blocklist?timeout=%s", skydTimeout)
+	url := fmt.Sprintf("http://%s:%d/skynet/blocklist?timeout=%s", skyd.staticNginxHost, skyd.staticNginxPort, skydTimeout)
 
 	skyd.staticLogger.Debugf("blockSkylinks: POST on %+s", url)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBodyBytes))


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR routes the call to block the Skylink through Nginx. This is necessary since we have a new mechanism in Nginx that prevents access to blocked skylinks. By routing it through Nginx, Nginx is aware that it should be updating its local cache.
Thereby ensuring the Skylink is no longer accessible, this takes immediate effect.

Tested on dev1
## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A