### PR TITLE
Retry On Failure

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,11 +16,11 @@ type API struct {
 	staticDB      *database.DB
 	staticLogger  *logrus.Logger
 	staticRouter  *httprouter.Router
-	staticSkydAPI *skyd.SkydAPI
+	staticSkydAPI skyd.API
 }
 
 // New creates a new API instance.
-func New(skydAPI *skyd.SkydAPI, db *database.DB, logger *logrus.Logger) (*API, error) {
+func New(skydAPI skyd.API, db *database.DB, logger *logrus.Logger) (*API, error) {
 	if db == nil {
 		return nil, errors.New("no DB provided")
 	}

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -118,6 +118,9 @@ func (bl *Blocker) RetryFailedSkylinks() error {
 
 	bl.staticLogger.Tracef("RetryFailedSkylinks blocked %v skylinks, and had %v failures", blocked, failed)
 
+	// NOTE: we purposefully do not update the latest block timestamp in the
+	// retry loop
+
 	return nil
 }
 
@@ -301,15 +304,6 @@ func (bl *Blocker) blockSkylinks(skylinks []database.BlockedSkylink) (succeeded 
 		// array of blocked skylinks
 		if err == nil {
 			blocked = append(blocked, skylinks[start:end]...)
-		}
-
-		// if no error has occurred yet, update the latest block timestamp
-		if len(failed) == 0 {
-			latest := skylinks[end-1]
-			err = bl.staticDB.SetLatestBlockTimestamp(latest.TimestampAdded)
-			if err != nil && err != database.ErrNoEntriesUpdated {
-				bl.staticLogger.Tracef("blockSkylinks failed to update timestamp: %s", err.Error())
-			}
 		}
 
 		// update start

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -251,6 +251,13 @@ func (bl *Blocker) blockSkylinks(skylinks []database.BlockedSkylink) (succeeded 
 		default:
 		}
 
+		// batchSize shouldn't ever be 0, but if it is zero we might get stuck
+		// in an endless loop, therefor we add this check here and break to
+		// ensure that never happens
+		if batchSize == 0 {
+			break
+		}
+
 		// calculate the end of the batch range
 		end := start + batchSize
 		if end > len(skylinks) {

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -17,6 +17,10 @@ const (
 	// simultaneously.
 	blockBatchSize = 100
 
+	// blockBatchSizeDivisor is the divisor applied to the batch size when an
+	// error is encountered.
+	blockBatchSizeDivisor = 10
+
 	// unableToUpdateBlocklistErrStr is a substring of the error returned by
 	// skyd if the blocklist was unable to get updated
 	unableToUpdateBlocklistErrStr = "unable to update the skynet blocklist"
@@ -273,7 +277,7 @@ func (bl *Blocker) blockSkylinks(skylinks []database.BlockedSkylink) (succeeded 
 		// simply decrease the batch size and continue
 		if err != nil && batchSize > 1 {
 			bl.staticLogger.Tracef("Error occurred while blocking skylinks retrying with batch size %v, err: %v, retrying with smaller batch size...", batchSize, err)
-			batchSize /= 10
+			batchSize /= blockBatchSizeDivisor
 			continue
 		}
 

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -81,7 +81,7 @@ func testBlockSkylinks(t *testing.T) {
 	// an error to be thrown in skyd, this will ensure the blocker tries:
 	// - all skylinks in 1 batch
 	// - a batch size of 10, which still fails
-	// - all skylinks in a batch size of 1, which returns the failing skykink
+	// - all skylinks in a batch size of 1, which returns the failing skylink
 	var skylinks []database.BlockedSkylink
 	var i int
 	for ; i < 9; i++ {

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -1,0 +1,155 @@
+package blocker
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SkynetLabs/blocker/database"
+	"github.com/SkynetLabs/blocker/skyd"
+	"github.com/sirupsen/logrus"
+	"gitlab.com/NebulousLabs/errors"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type mockSkyd struct {
+	BlockSkylinksReqs [][]string
+}
+
+// BlockSkylinks adds the given skylinks to the block list.
+func (api *mockSkyd) BlockSkylinks(skylinks []string) error {
+	api.BlockSkylinksReqs = append(api.BlockSkylinksReqs, skylinks)
+
+	// check whether the caller expects an error to be thrown
+	for _, sl := range skylinks {
+		if sl == "throwerror" {
+			return errors.New("error")
+		}
+	}
+	return nil
+}
+
+// IsSkydUp returns true if the skyd API instance is up.
+func (api *mockSkyd) IsSkydUp() bool {
+	return true
+}
+
+// ResolveSkylink tries to resolve the given skylink to a V1 skylink.
+func (api *mockSkyd) ResolveSkylink(skylink string) (string, error) {
+	return skylink, nil
+}
+
+// TestBlocker runs the blocker unit tests
+func TestBlocker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "BlockSkylinks",
+			test: testBlockSkylinks,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, test.test)
+	}
+}
+
+// testBlockSkylinks is a unit test that covers the 'blockSkylinks' method.
+func testBlockSkylinks(t *testing.T) {
+	// create a mock skyd api
+	api := &mockSkyd{}
+
+	// create the blocker
+	blocker, err := newTestBlocker("BlockSkylinks", api)
+	if err != nil {
+		panic(err)
+	}
+
+	ts := time.Now().UTC()
+	ts = ts.Truncate(time.Second)
+
+	// create a list of 16 skylinks, where the 10th skylink is one that triggers
+	// an error to be thrown in skyd, this will ensure the blocker tries:
+	// - all skylinks in 1 batch
+	// - a batch size of 10, which still fails
+	// - all skylinks in a batch size of 1, which returns the failing skykink
+	var skylinks []database.BlockedSkylink
+	var i int
+	for ; i < 9; i++ {
+		ts = ts.Add(time.Minute)
+		skylinks = append(skylinks, database.BlockedSkylink{Skylink: fmt.Sprintf("skylink_%d", i), TimestampAdded: ts})
+	}
+
+	// the last skylink before the failure should be the latest timestamp set,
+	// so save this timestamp as an expected value for later
+	expectedLatest := ts
+	skylinks = append(skylinks, database.BlockedSkylink{Skylink: "throwerror"})
+	for ; i < 15; i++ {
+		ts = ts.Add(time.Minute)
+		skylinks = append(skylinks, database.BlockedSkylink{Skylink: fmt.Sprintf("skylink_%d", i), TimestampAdded: ts})
+	}
+
+	err = blocker.blockSkylinks(skylinks)
+	if err == nil {
+		t.Fatal("expected error to be thrown")
+	}
+	// assert the error contains the skylink that failed
+	if !strings.Contains(err.Error(), "failed blocking skylink 'throwerror'") {
+		t.Fatal("unexpected error thrown")
+	}
+
+	// assert 18 requests in total happen to skyd, batch size 100, 10 and 1
+	if len(api.BlockSkylinksReqs) != 18 {
+		t.Fatalf("unexpected amount of calls to Skyd block endpoint, %v != 18", len(api.BlockSkylinksReqs))
+	}
+	if len(api.BlockSkylinksReqs[0]) != 16 {
+		t.Fatalf("unexpected first batch size, %v != 16", len(api.BlockSkylinksReqs[0]))
+	}
+	if len(api.BlockSkylinksReqs[1]) != 10 {
+		t.Fatalf("unexpected second batch size, %v != 10", len(api.BlockSkylinksReqs[1]))
+	}
+	for r := 2; r < 18; r++ {
+		if len(api.BlockSkylinksReqs[r]) != 1 {
+			t.Fatalf("unexpected batch size for req %d, %v != 1", r, len(api.BlockSkylinksReqs[r]))
+		}
+	}
+
+	// assert the latest block timestamp has been set to the timestamp of the
+	// last succeeding skylink before the failure
+	latest, err := blocker.staticDB.LatestBlockTimestamp()
+	if err != nil {
+		t.Fatal("failed to fetch latest block timestamp", err)
+	}
+	if latest != expectedLatest {
+		t.Fatalf("latest block timestamp not updated to last succeeding skylink timestamp added, %v != %v", latest, expectedLatest)
+	}
+}
+
+// newTestBlocker returns a new blocker instance
+func newTestBlocker(dbName string, api skyd.API) (*Blocker, error) {
+	// create a nil logger
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	// create database
+	db, err := database.NewCustomDB(context.Background(), "mongodb://localhost:37017", dbName, options.Credential{
+		Username: "admin",
+		Password: "aO4tV5tC1oU3oQ7u",
+	}, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// create the blocker
+	blocker, err := New(context.Background(), api, db, logger, "", "")
+	if err != nil {
+		return nil, err
+	}
+	return blocker, nil
+}

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // mockSkyd is a helper struct that implements the skyd API, all methods are
-// essentially a no-op except for 'BlockSkysslinks' which keeps track of the
+// essentially a no-op except for 'BlockSkylinks' which keeps track of the
 // arguments with which it is called
 type mockSkyd struct {
 	BlockSkylinksReqs [][]string
@@ -47,6 +47,9 @@ func (api *mockSkyd) ResolveSkylink(skylink string) (string, error) {
 
 // TestBlocker runs the blocker unit tests
 func TestBlocker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	t.Parallel()
 
 	tests := []struct {
@@ -75,7 +78,11 @@ func testBlockSkylinks(t *testing.T) {
 	}
 
 	// defer a db close
-	defer blocker.staticDB.Close()
+	defer func() {
+		if err := blocker.staticDB.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	ts := time.Now().UTC()
 	ts = ts.Truncate(time.Second)

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +28,7 @@ func (api *mockSkyd) BlockSkylinks(skylinks []string) error {
 	// check whether the caller expects an error to be thrown
 	for _, sl := range skylinks {
 		if sl == "throwerror" {
-			return errors.New("error")
+			return errors.New(unableToUpdateBlocklistErrStr)
 		}
 	}
 	return nil
@@ -109,8 +108,8 @@ func testBlockSkylinks(t *testing.T) {
 	}
 
 	blocked, failed, err := blocker.blockSkylinks(skylinks)
-	if err == nil {
-		t.Fatal("expected error to be thrown")
+	if err != nil {
+		t.Fatal("unexpected error thrown", err)
 	}
 	// assert blocked and failed are returned correctly
 	if blocked != 15 {
@@ -118,10 +117,6 @@ func testBlockSkylinks(t *testing.T) {
 	}
 	if failed != 1 {
 		t.Fatalf("unexpected return values for failed, %v != 1", failed)
-	}
-	// assert the error contains the skylink that failed
-	if !strings.Contains(err.Error(), "failed blocking skylink 'throwerror'") {
-		t.Fatal("unexpected error thrown")
 	}
 
 	// assert 18 requests in total happen to skyd, batch size 100, 10 and 1

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -15,6 +15,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// mockSkyd is a helper struct that implements the skyd API, all methods are
+// essentially a no-op except for 'BlockSkysslinks' which keeps track of the
+// arguments with which it is called
 type mockSkyd struct {
 	BlockSkylinksReqs [][]string
 }

--- a/database/database.go
+++ b/database/database.go
@@ -227,9 +227,7 @@ func (db *DB) SkylinksToBlock() ([]BlockedSkylink, error) {
 // for it to run smoothly.
 func (db *DB) SkylinksToRetry() ([]BlockedSkylink, error) {
 	filter := bson.M{"failed": bson.M{"$eq": true}}
-	opts := options.Find()
-	opts.SetSort(bson.D{{"timestamp_added", -1}})
-	c, err := db.staticDB.Collection(dbSkylinks).Find(db.ctx, filter, opts)
+	c, err := db.staticDB.Collection(dbSkylinks).Find(db.ctx, filter)
 	if err != nil && errors.Contains(err, ErrNoDocumentsFound) {
 		return nil, nil
 	} else if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -62,7 +62,8 @@ func New(ctx context.Context, uri string, creds options.Credential, logger *logr
 	return NewCustomDB(ctx, uri, dbName, creds, logger)
 }
 
-// NewCustomDB creates a new database connection to a database with a custom name.
+// NewCustomDB creates a new database connection to a database with a custom
+// name.
 func NewCustomDB(ctx context.Context, uri string, dbName string, creds options.Credential, logger *logrus.Logger) (*DB, error) {
 	if ctx == nil {
 		return nil, errors.New("invalid context provided")

--- a/database/database.go
+++ b/database/database.go
@@ -227,7 +227,9 @@ func (db *DB) SkylinksToBlock() ([]BlockedSkylink, error) {
 // for it to run smoothly.
 func (db *DB) SkylinksToRetry() ([]BlockedSkylink, error) {
 	filter := bson.M{"failed": bson.M{"$eq": true}}
-	c, err := db.staticDB.Collection(dbSkylinks).Find(db.ctx, filter)
+	opts := options.Find()
+	opts.SetSort(bson.D{{"timestamp_added", -1}})
+	c, err := db.staticDB.Collection(dbSkylinks).Find(db.ctx, filter, opts)
 	if err != nil && errors.Contains(err, ErrNoDocumentsFound) {
 		return nil, nil
 	} else if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -133,8 +133,8 @@ func (db *DB) BlockedSkylink(ctx context.Context, s string) (*BlockedSkylink, er
 	return &sl, nil
 }
 
-// CreateBlockedSkylink creates a new skylink. If the skylink already exists it does
-// nothing.
+// CreateBlockedSkylink creates a new skylink. If the skylink already exists it
+// does nothing.
 func (db *DB) CreateBlockedSkylink(ctx context.Context, skylink *BlockedSkylink) error {
 	_, err := db.staticSkylinks.InsertOne(ctx, skylink)
 	if err != nil && strings.Contains(err.Error(), "E11000 duplicate key error collection") {
@@ -217,8 +217,6 @@ func (db *DB) SkylinksToBlock() ([]BlockedSkylink, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	db.staticLogger.Tracef("SkylinksToBlock: returning list %v", list)
 	return list, nil
 }
 
@@ -240,8 +238,6 @@ func (db *DB) SkylinksToRetry() ([]BlockedSkylink, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	db.staticLogger.Tracef("SkylinksToRetry: returning list %v", list)
 	return list, nil
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -227,7 +227,9 @@ func (db *DB) SkylinksToBlock() ([]BlockedSkylink, error) {
 // for it to run smoothly.
 func (db *DB) SkylinksToRetry() ([]BlockedSkylink, error) {
 	filter := bson.M{"failed": bson.M{"$eq": true}}
-	c, err := db.staticDB.Collection(dbSkylinks).Find(db.ctx, filter)
+	opts := options.Find()
+	opts.SetSort(bson.D{{"timestamp_added", 1}})
+	c, err := db.staticDB.Collection(dbSkylinks).Find(db.ctx, filter, opts)
 	if err != nil && errors.Contains(err, ErrNoDocumentsFound) {
 		return nil, nil
 	} else if err != nil {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -41,6 +41,9 @@ func newTestDB(ctx context.Context, dbName string) *DB {
 
 // TestDatabase runs the database unit tests.
 func TestDatabase(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	t.Parallel()
 
 	tests := []struct {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -14,7 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// newTestDB creates a new database for a given test's name.
+// NewTestDB creates a new database for a given test's name.
 func newTestDB(dbName string) *DB {
 	dbName = strings.ReplaceAll(dbName, "/", "-")
 	logger := logrus.New()

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -21,6 +21,7 @@ type BlockedSkylink struct {
 	Skylink           string             `bson:"skylink"`
 	Reporter          Reporter           `bson:"reporter"`
 	Reverted          bool               `bson:"reverted"`
+	Failed            bool               `bson:"failed"`
 	RevertedTags      []string           `bson:"reverted_tags"`
 	Tags              []string           `bson:"tags"`
 	TimestampAdded    time.Time          `bson:"timestamp_added"`

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 	}
 
 	// Create a skyd API.
-	skydAPI, err := skyd.NewSkydAPI(nginxHost, nginxPort, skydHost, skydAPIPassword, skydPort, db, logger)
+	skydAPI, err := skyd.NewAPI(nginxHost, nginxPort, skydHost, skydAPIPassword, skydPort, db, logger)
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to instantiate Skyd API"))
 	}

--- a/main.go
+++ b/main.go
@@ -34,24 +34,6 @@ const (
 	// defaultNginxPort is where we connect to nginx unless overwritten by
 	// "NGINX_PORT" environment variables.
 	defaultNginxPort = 8000
-
-	// defaultNginxCachePurgerListPath is the path at which we can find the list where
-	// we want to add the skylinks which we want purged from nginx's cache.
-	//
-	// NOTE: this value can be configured via the BLOCKER_NGINX_CACHE_PURGE_LIST
-	// environment variable, however it is important that this path matches the
-	// path in the nginx purge script that is part of the cron.
-	defaultNginxCachePurgerListPath = "/data/nginx/blocker/skylinks.txt"
-
-	// defaultNginxCachePurgeLockPath is the path to the lock directory. The blocker
-	// acquires this lock before writing to the list file, essentially ensuring
-	// the purge script does not alter the file while the blocker API is writing
-	// to it.
-	//
-	// NOTE: this value can be configured via the BLOCKER_NGINX_CACHE_PURGE_LOCK
-	// environment variable, however it is important that this path matches the
-	// path in the nginx purge script that is part of the cron.
-	defaultNginxCachePurgeLockPath = "/data/nginx/blocker/lock"
 )
 
 // loadDBCredentials creates a new db connection based on credentials found in
@@ -147,16 +129,6 @@ func main() {
 		api.AccountsPort = aPort
 	}
 
-	// Initialise and start the background scanner task.
-	nginxCachePurgerListPath := defaultNginxCachePurgerListPath
-	if nginxList := os.Getenv("BLOCKER_NGINX_CACHE_PURGE_LIST"); nginxList != "" {
-		nginxCachePurgerListPath = nginxList
-	}
-	nginxCachePurgeLockPath := defaultNginxCachePurgeLockPath
-	if nginxLock := os.Getenv("BLOCKER_NGINX_CACHE_PURGE_LOCK"); nginxLock != "" {
-		nginxCachePurgeLockPath = nginxLock
-	}
-
 	// Create a skyd API.
 	skydAPI, err := skyd.NewAPI(nginxHost, nginxPort, skydHost, skydAPIPassword, skydPort, db, logger)
 	if err != nil {
@@ -167,7 +139,7 @@ func main() {
 	}
 
 	// Create the blocker.
-	blockerThread, err := blocker.New(ctx, skydAPI, db, logger, nginxCachePurgerListPath, nginxCachePurgeLockPath)
+	blockerThread, err := blocker.New(ctx, skydAPI, db, logger)
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to instantiate blocker"))
 	}


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PR adds a retry loop for skylinks that failed to get blocked the first time around.
Currently, a single Skylink that skyd fails to process can hold up the entire queue.

It adds a retry with a decreased batch size up until the point the batch count is 1. 
At that point, the faulty Skylink is identified and it will be marked as `failed`.

There's a secondary loop that handles these skylinks. Upon success in this loop, the document will be marked as succeeded and never handled again, seeing as the primary loop will have updated the latest block timestamp by now to a timestamp that far exceeds the `timestamp_added` of the blocked skylink.

If the Skylink keeps failing though, it keeps being retried forever. The plan is to follow up with a mechanism that notifies us that this is happening so we can act accordingly.
I had to make a bunch of minor changes in order to be able to add basic unit testing.


edit:

This PR also: 
- renames `skydAPI` to `API` to remove the stuttering
- removes writing skylinks to nginx purge path
- adds an interface for the `API` so we can easily mock skyd in testing
 
## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods

## Issues Closed
N/A