### PR TITLE
[HOTFIX] Avoid Deadlock

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -347,10 +347,10 @@ func ensureDBSchema(ctx context.Context, db *mongo.Database, log *logrus.Logger)
 				Keys:    bson.D{{"skylink", 1}},
 				Options: options.Index().SetName("skylink").SetUnique(true),
 			},
-			{
-				Keys:    bson.D{{"failed", 1}},
-				Options: options.Index().SetName("failed"),
-			},
+			// {
+			// 	Keys:    bson.D{{"failed", 1}},
+			// 	Options: options.Index().SetName("failed"),
+			// },
 			{
 				Keys:    bson.D{{"timestamp_added", 1}},
 				Options: options.Index().SetName("timestamp_added"),

--- a/database/database.go
+++ b/database/database.go
@@ -77,7 +77,7 @@ func NewCustomDB(ctx context.Context, uri string, dbName string, creds options.C
 	}
 
 	// Define a new context with a timeout to handle the database setup.
-	dbCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	dbCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	// Prepare the options for connecting to the db.

--- a/database/database.go
+++ b/database/database.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	// ErrIndexCreateFailed is returned when an error occurred whilst trying to
+	// ErrIndexCreateFailed is returned when an error occurred when trying to
 	// ensure an index
 	ErrIndexCreateFailed = errors.New("failed to create index")
 
@@ -102,9 +102,10 @@ func NewCustomDB(ctx context.Context, uri string, dbName string, creds options.C
 	db := c.Database(dbName)
 	err = ensureDBSchema(dbCtx, db, logger)
 	if err != nil && errors.Contains(err, ErrIndexCreateFailed) {
-		// Do not fail here if we could not ensure the existence of an index. It
-		// should definitely be looked into, but this is no reason to prevent
-		// the blocker from running.
+		// We do not error out if we failed to ensure the existence of an index.
+		// It is definitely an issue that should be looked into, which is why we
+		// tag it as [CRITICAL], but seeing as the blocker will work the same
+		// without the index it's no reason to prevent it from running.
 		logger.Errorf(`[CRITICAL] failed to ensure DB schema, err: %v`, err)
 	} else if err != nil {
 		return nil, err

--- a/database/database.go
+++ b/database/database.go
@@ -350,18 +350,18 @@ func ensureDBSchema(ctx context.Context, db *mongo.Database, log *logrus.Logger)
 		},
 	}
 
-	for collName, models := range schema {
-		coll, err := ensureCollection(ctx, db, collName)
+	for collName := range schema {
+		_, err := ensureCollection(ctx, db, collName)
 		if err != nil {
 			return err
 		}
-		iv := coll.Indexes()
-		var names []string
-		names, err = iv.CreateMany(ctx, models)
-		if err != nil {
-			return errors.AddContext(err, "failed to create indexes")
-		}
-		log.Debugf("Ensured index exists: %v", names)
+		// iv := coll.Indexes()
+		// var names []string
+		// names, err = iv.CreateMany(ctx, models)
+		// if err != nil {
+		// 	return errors.AddContext(err, "failed to create indexes")
+		// }
+		// log.Debugf("Ensured index exists: %v", names)
 	}
 	return nil
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -15,12 +15,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-const (
-	// defaultMongoTimeout is the timeout for the context used in testing
-	// whenever a context is sent to mongo
-	defaultMongoTimeout = 30 * time.Second
-)
-
 // newTestDB creates a new database for a given test's name.
 func newTestDB(ctx context.Context, dbName string) *DB {
 	dbName = strings.ReplaceAll(dbName, "/", "-")
@@ -79,7 +73,7 @@ func TestDatabase(t *testing.T) {
 // testPing is a unit test for the database's Ping method.
 func testPing(t *testing.T) {
 	// create context
-	ctx, cancel := context.WithTimeout(context.Background(), defaultMongoTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), mongoDefaultTimeout)
 	defer cancel()
 
 	// create test database
@@ -103,7 +97,7 @@ func testPing(t *testing.T) {
 // the db.
 func testCreateBlockedSkylink(t *testing.T) {
 	// create context
-	ctx, cancel := context.WithTimeout(context.Background(), defaultMongoTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), mongoDefaultTimeout)
 	defer cancel()
 
 	// create test database
@@ -154,7 +148,7 @@ func testCreateBlockedSkylink(t *testing.T) {
 // testIsAllowListedSkylink tests the 'IsAllowListed' method on the database.
 func testIsAllowListedSkylink(t *testing.T) {
 	// create context
-	ctx, cancel := context.WithTimeout(context.Background(), defaultMongoTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), mongoDefaultTimeout)
 	defer cancel()
 
 	// create test database
@@ -196,7 +190,7 @@ func testIsAllowListedSkylink(t *testing.T) {
 // the 'MarkAsSucceeded' method on the database.
 func testMarkAsSucceeded(t *testing.T) {
 	// create context
-	ctx, cancel := context.WithTimeout(context.Background(), defaultMongoTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), mongoDefaultTimeout)
 	defer cancel()
 
 	// create test database
@@ -244,7 +238,7 @@ func testMarkAsSucceeded(t *testing.T) {
 // the 'MarkAsFailed' method on the database.
 func testMarkAsFailed(t *testing.T) {
 	// create context
-	ctx, cancel := context.WithTimeout(context.Background(), defaultMongoTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), mongoDefaultTimeout)
 	defer cancel()
 
 	// create test database


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR is meant as a temporary measure to get rid of the deadlock we are experiencing on production. For some reason, the nodes can't reach the primary when trying to ensure indices, since the database setup is being done with a `context.Background` there is a deadlock situation.

This PR essentially wraps the DB setup in a 1-minute context and simply logs the error instead of failing to start the blocker container, providing the issue was related to the creation of an index. An index not being present is not ideal, but it's not preventing the blocker from functioning either.

I have tested this on `eu-fin-8` and verified that it indeed gets rid of the deadlock and ensures the container starts up.
```
blocker             | time="2022-01-15T16:01:01Z" level=debug msg="Ensured index exists: [server_name]"
blocker             | time="2022-01-15T16:01:02Z" level=debug msg="Ensured index exists: [skylink timestamp_added]"
blocker             | time="2022-01-15T16:02:01Z" level=error msg="[CRITICAL] failed to ensure DB schema, err: [connection(us-va-2.siasky.net:27017[-104]) incomplete read of message header: context deadline exceeded; failed to create index]"
blocker             | time="2022-01-15T16:02:01Z" level=info msg="Listening on port 4000"
blocker             | time="2022-01-15T16:02:02Z" level=debug msg="SweepAndBlock ran successfully."
```

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A