### PR TITLE
Use Skylink Hash (pt1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # blocker
 
-Blocker is a service that blocklists all bad skylinks on the current server.
+Blocker is a service that blocklists all abusive skylinks on the current server.
+The service exposes a REST API that allows callers to request the blocking of
+new skylinks. The blocklist is shared between the servers that make up a portal
+cluster via MongoDB.
 
-The service exposes a REST API that allows callers to request the blocking of new skylinks.
+# Hashes
 
-The blocklist is shared between the servers that make up a portal cluster via MongoDB.
+The blocker will convert the Skylink to a hash of its merkle root as soon as
+possible. This to prevent the persistence of abusive skylinks in the database
+and/or log files.
 
 # AllowList
 
@@ -21,20 +26,23 @@ db.getCollection('allowlist').insertOne({
 ```
 
 The skylink is expected to be in the following form: `_B19BtlWtjjR7AD0DDzxYanvIhZ7cxXrva5tNNxDht1kaA`.
-So that's without portal and without the `sia://` prefix.
+So that's without portal and without the `sia://` prefix. The allow list is
+persisted as is, so not as a hash, for ease of use and because it is assumed the
+allowlist only holds non-abusive content.
 
 # Environment
 
 This service depends on the following environment variables:
-* `PORTAL_DOMAIN`, e.g. `siasky.net`
-* `API_HOST`, e.g. `sia` (defaults to `sia`)
-* `API_PORT`, e.g. `9980` (defaults to `9980`)
+* `API_HOST`, defaults to `sia`
+* `API_PORT`, defaults to `9980`
 * `SIA_API_PASSWORD`
-* `SERVER_DOMAIN`, e.g. `eu-ger-5.siasky.net`
-* `BLOCKER_LOG_LEVEL`, defaults to `info`
+* `NGINX_HOST`, defaults to `10.10.10.30`
+* `NGINX_PORT`, defaults to `8000`
 * `SKYNET_DB_HOST`
 * `SKYNET_DB_PORT`
 * `SKYNET_DB_USER`
 * `SKYNET_DB_PASS`
 * `SKYNET_ACCOUNTS_HOST`, defaults to `accounts`
 * `SKYNET_ACCOUNTS_PORT`, defaults to `3000`
+* `SERVER_DOMAIN`, e.g. `eu-ger-5.siasky.net`
+* `BLOCKER_LOG_LEVEL`, defaults to `info`

--- a/api/api.go
+++ b/api/api.go
@@ -11,7 +11,8 @@ import (
 	"gitlab.com/NebulousLabs/errors"
 )
 
-// API is our central entry point to all subsystems relevant to serving requests.
+// API is our central entry point to all subsystems relevant to serving
+// requests.
 type API struct {
 	staticDB      *database.DB
 	staticLogger  *logrus.Logger

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -228,12 +228,12 @@ func (api *API) block(ctx context.Context, bp BlockPOST, skylink skymodules.Skyl
 		Tags:           bp.Tags,
 		TimestampAdded: time.Now().UTC(),
 	}
-	api.staticLogger.Tracef("blockPOST will block Skylink hash %s", bs.Hash)
+	api.staticLogger.Debugf("blocking hash %s", bs.Hash)
 	err := api.staticDB.CreateBlockedSkylink(ctx, bs)
 	if err != nil {
 		return err
 	}
-	api.staticLogger.Debugf("Added Skylink hash %s", bs.Hash)
+	api.staticLogger.Debugf("blocked hash %s", bs.Hash)
 	return nil
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -177,9 +177,11 @@ func (api *API) handleBlockRequest(ctx context.Context, w http.ResponseWriter, b
 	_ = skylink.LoadString(string(bp.Skylink))
 
 	// Resolve the skylink
-	var err error
-	skylink, err = api.staticSkydAPI.ResolveSkylink(skylink)
-	if err != nil {
+	resolved, err := api.staticSkydAPI.ResolveSkylink(skylink)
+	if err == nil {
+		// replace the skylink with the resolved skylink
+		skylink = resolved
+	} else {
 		// in case of an error we log and continue with the given skylink
 		api.staticLogger.Errorf("failed to resolve skylink '%v', err: %v", skylink, err)
 	}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -16,6 +16,12 @@ import (
 	"gitlab.com/SkynetLabs/skyd/skymodules"
 )
 
+var (
+	// maxBodySize defines the maximum size of the POST body when making request
+	// to the block endpoints
+	maxBodySize = int64(1 << 16) // 64kib
+)
+
 type (
 	// BlockPOST describes a request to the /block endpoint.
 	BlockPOST struct {
@@ -103,7 +109,7 @@ func (api *API) healthGET(w http.ResponseWriter, r *http.Request, _ httprouter.P
 // to be done by means of 'authenticating' the caller.
 func (api *API) blockPOST(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Protect against large bodies.
-	b := http.MaxBytesReader(w, r.Body, 1<<16) // 64 kib
+	b := http.MaxBytesReader(w, r.Body, maxBodySize)
 	defer b.Close()
 
 	// Parse the request.
@@ -115,7 +121,7 @@ func (api *API) blockPOST(w http.ResponseWriter, r *http.Request, _ httprouter.P
 	}
 
 	// Get the sub from the form
-	sub := r.Form.Get("sub")
+	sub := r.FormValue("sub")
 	if sub == "" {
 		// No sub. Maybe we didn't try to fetch it? Try now. Don't log errors.
 		u, err := UserFromReq(r, api.staticLogger)
@@ -135,7 +141,7 @@ func (api *API) blockPOST(w http.ResponseWriter, r *http.Request, _ httprouter.P
 // us to more easily unblock a batch of links.
 func (api *API) blockWithPoWPOST(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Protect against large bodies.
-	b := http.MaxBytesReader(w, r.Body, 1<<16) // 64 kib
+	b := http.MaxBytesReader(w, r.Body, maxBodySize)
 	defer b.Close()
 
 	// Parse the request.

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -125,7 +125,7 @@ func (api *API) blockPOST(w http.ResponseWriter, r *http.Request, _ httprouter.P
 		}
 	}
 
-	// Further handle the request
+	// Handle the request
 	api.handleBlockRequest(r.Context(), w, body, sub)
 }
 
@@ -157,7 +157,7 @@ func (api *API) blockWithPoWPOST(w http.ResponseWriter, r *http.Request, _ httpr
 		return
 	}
 
-	// Further handle the request
+	// Handle the request
 	api.handleBlockRequest(r.Context(), w, body.BlockPOST, sub)
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -14,7 +14,6 @@ import (
 	"gitlab.com/NebulousLabs/errors"
 	skyapi "gitlab.com/SkynetLabs/skyd/node/api"
 	"gitlab.com/SkynetLabs/skyd/skymodules"
-	"go.sia.tech/siad/crypto"
 )
 
 type (
@@ -217,7 +216,7 @@ func (api *API) block(ctx context.Context, bp BlockPOST, skylink skymodules.Skyl
 	// dropped.
 	bs := &database.BlockedSkylink{
 		Skylink: skylink.String(),
-		Hash:    crypto.Hash(skylink.MerkleRoot()),
+		Hash:    database.NewHash(skylink),
 		Reporter: database.Reporter{
 			Name:            bp.Reporter.Name,
 			Email:           bp.Reporter.Email,

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -1,9 +1,222 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"testing"
+	"time"
+
+	"github.com/SkynetLabs/blocker/database"
+	"github.com/SkynetLabs/blocker/skyd"
+	"github.com/sirupsen/logrus"
+	"gitlab.com/SkynetLabs/skyd/skymodules"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.sia.tech/siad/crypto"
 )
+
+var (
+	// v1SkylinkStr is a random skylink
+	v1SkylinkStr = "BAAWi3ou51qCH24Im0ESS-5_gKg60qGIYtta-ryrl1kBnQ"
+	// v2SkylinkStr is a v2 skylink that resolves to the v1 skylink
+	v2SkylinkStr = "AQBst6HgaJ0PIBMtmQ2qgH_wQlFg4bNnwAhff7DmJP6oyg"
+)
+
+// mockSkyd is a helper struct that implements the Skyd API interface
+type mockSkyd struct{}
+
+// the following methods are the implementation of the interface, it's
+// essentially all no-ops except for the resolver which resolves a predefined v2
+// skylink to its v1.
+func (api *mockSkyd) BlockHashes(hashes []string) error { return nil }
+func (api *mockSkyd) IsSkydUp() bool                    { return true }
+func (api *mockSkyd) ResolveSkylink(skylink skymodules.Skylink) (skymodules.Skylink, error) {
+	if skylink.IsSkylinkV2() && skylink.String() == v2SkylinkStr {
+		var v1 skymodules.Skylink
+		if err := v1.LoadString(v1SkylinkStr); err != nil {
+			panic(err)
+		}
+		return v1, nil
+	}
+	return skylink, nil
+}
+
+// mockResponseWriter is a helper struct that implements the response writer
+// interface.
+type mockResponseWriter struct {
+	staticBuffer *bytes.Buffer
+	staticHeader http.Header
+}
+
+// the following methods are the implementation of the interface, it's
+// essentially all no-ops except for write, which simply writes to an internal
+// buffer that can be accessed in testing
+func (rw *mockResponseWriter) Header() http.Header         { return rw.staticHeader }
+func (rw *mockResponseWriter) Write(b []byte) (int, error) { return rw.staticBuffer.Write(b) }
+func (rw *mockResponseWriter) WriteHeader(statusCode int)  {}
+
+// Reset is a helper function that resets the response writer, this avoids
+// having to create a new one between assertions
+func (rw *mockResponseWriter) Reset() {
+	rw.staticBuffer.Reset()
+	for k := range rw.staticHeader {
+		delete(rw.staticHeader, k)
+	}
+}
+
+func newMockResponseWriter() *mockResponseWriter {
+	header := make(http.Header)
+	return &mockResponseWriter{
+		staticBuffer: bytes.NewBuffer(nil),
+		staticHeader: header,
+	}
+}
+
+// TestHandlers runs the handlers unit tests.
+func TestHandlers(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "HandleBlockRequest",
+			test: testHandleBlockRequest,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, test.test)
+	}
+}
+
+// testHandleBlockRequest verifies the functionality of the block request
+// handler in the API, this method is called by both the regular and PoW block
+// routes and contains all shared logic.
+func testHandleBlockRequest(t *testing.T) {
+	// create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+	defer cancel()
+
+	// create a new test API
+	skyd := &mockSkyd{}
+	api, err := newTestAPI("HandleBlockRequest", skyd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a response writer
+	w := newMockResponseWriter()
+
+	// allow list a skylink
+	err = api.staticDB.CreateAllowListedSkylink(ctx, &database.AllowListedSkylink{
+		Skylink:        v1SkylinkStr,
+		Description:    "test skylink",
+		TimestampAdded: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a block request for our v2 skylink
+	bp := BlockPOST{
+		Reporter: Reporter{
+			Name:         "John",
+			Email:        "john@example.com",
+			OtherContact: "other@example.com",
+		},
+		Skylink: skylink(v2SkylinkStr),
+		Tags:    []string{"tag_a", "tag_b"},
+	}
+
+	// call the request handler
+	api.handleBlockRequest(context.Background(), w, bp, "")
+
+	// assert the handler writes a 'reported' status response
+	var resp statusResponse
+	err = json.Unmarshal(w.staticBuffer.Bytes(), &resp)
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if resp.Status != "reported" {
+		t.Fatal("unexpected response status", resp.Status)
+	}
+
+	// assert the blocked skylink did not make it into the database
+	var sl skymodules.Skylink
+	err = sl.LoadString(v1SkylinkStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := api.staticDB.FindByHash(ctx, crypto.Hash(sl.MerkleRoot()))
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if doc != nil {
+		t.Fatal("unexpected blocked skylink found", doc)
+	}
+
+	// up until now we have asserted that the skylink gets resolved and the
+	// allow list gets checked, note that this is only meaningful if the below
+	// assertions pass also (happy path)
+
+	// load a random skylink
+	err = sl.LoadString("_B19BtlWtjjR7AD0DDzxYanvIhZ7cxXrva5tNNxDht1kaA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a block request for a random skylink
+	bp = BlockPOST{
+		Reporter: Reporter{
+			Name:         "John",
+			Email:        "john@example.com",
+			OtherContact: "other@example.com",
+		},
+		Skylink: skylink(sl.String()),
+		Tags:    []string{"tag_c", "tag_d"},
+	}
+
+	// call the request handler
+	w.Reset()
+	api.handleBlockRequest(context.Background(), w, bp, "")
+
+	// assert the handler writes a 'reported' status response
+	err = json.Unmarshal(w.staticBuffer.Bytes(), &resp)
+	if err != nil {
+		t.Fatal("unexpected error", err, string(w.staticBuffer.Bytes()))
+	}
+	if resp.Status != "reported" {
+		t.Fatal("unexpected response status", resp.Status)
+	}
+
+	// assert the blocked skylink made it into the database
+	doc, err = api.staticDB.FindByHash(ctx, crypto.Hash(sl.MerkleRoot()))
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if doc == nil {
+		t.Fatal("expected blocked skylink to be found")
+	}
+
+	// call the request handler with the same parameters
+	w.Reset()
+	api.handleBlockRequest(context.Background(), w, bp, "")
+
+	// assert the handler writes a 'duplicate' status response
+	err = json.Unmarshal(w.staticBuffer.Bytes(), &resp)
+	if err != nil {
+		t.Fatal("unexpected error", err, string(w.staticBuffer.Bytes()))
+	}
+	if resp.Status != "duplicate" {
+		t.Fatal("unexpected response status", resp.Status)
+	}
+}
 
 // TestVerifySkappReport verifies a report directly generated from the abuse
 // skapp.
@@ -20,4 +233,37 @@ func TestVerifySkappReport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// newTestAPI returns a new API instance
+func newTestAPI(dbName string, skyd skyd.API) (*API, error) {
+	// create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+	defer cancel()
+
+	// create a nil logger
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	// create database
+	db, err := database.NewCustomDB(ctx, "mongodb://localhost:37017", dbName, options.Credential{
+		Username: "admin",
+		Password: "aO4tV5tC1oU3oQ7u",
+	}, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// purge the database
+	err = db.Purge(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// create the API
+	api, err := New(skyd, db, logger)
+	if err != nil {
+		return nil, err
+	}
+	return api, nil
 }

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.sia.tech/siad/crypto"
 )
 
 var (
@@ -153,7 +152,7 @@ func testHandleBlockRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	doc, err := api.staticDB.FindByHash(ctx, crypto.Hash(sl.MerkleRoot()))
+	doc, err := api.staticDB.FindByHash(ctx, database.NewHash(sl))
 	if err != nil {
 		t.Fatal("unexpected error", err)
 	}
@@ -196,7 +195,7 @@ func testHandleBlockRequest(t *testing.T) {
 	}
 
 	// assert the blocked skylink made it into the database
-	doc, err = api.staticDB.FindByHash(ctx, crypto.Hash(sl.MerkleRoot()))
+	doc, err = api.staticDB.FindByHash(ctx, database.NewHash(sl))
 	if err != nil {
 		t.Fatal("unexpected error", err)
 	}

--- a/api/routes.go
+++ b/api/routes.go
@@ -16,8 +16,11 @@ import (
 
 var (
 	// AccountsHost is the host on which the accounts service is listening.
+	// NOTE: this variable is overwritten with what is set in the environment
 	AccountsHost = "accounts"
+
 	// AccountsPort is the port on which the accounts service is listening.
+	// NOTE: this variable is overwritten with what is set in the environment
 	AccountsPort = "3000"
 )
 

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/SkynetLabs/skynet-accounts/build"
 	"github.com/sirupsen/logrus"
 	"gitlab.com/NebulousLabs/errors"
-	"go.sia.tech/siad/crypto"
 )
 
 const (
@@ -230,13 +229,13 @@ func (bl *Blocker) Start() {
 }
 
 // blockHashes blocks the given list of hashes.
-func (bl *Blocker) blockHashes(hashes []crypto.Hash) (succeeded int, failures int, err error) {
+func (bl *Blocker) blockHashes(hashes []database.Hash) (succeeded int, failures int, err error) {
 	batchSize := blockBatchSize
 	start := 0
 
 	// keep track of which skylinks were blocked and which ones failed
-	var blocked []crypto.Hash
-	var failed []crypto.Hash
+	var blocked []database.Hash
+	var failed []database.Hash
 
 	// defer a function that updates the database and sets return values
 	defer func() {

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -57,7 +57,7 @@ func TestBlocker(t *testing.T) {
 		test func(t *testing.T)
 	}{
 		{
-			name: "BlockSkylinks",
+			name: "BlockHashes",
 			test: testBlockHashes,
 		},
 	}
@@ -72,7 +72,7 @@ func testBlockHashes(t *testing.T) {
 	api := &mockSkyd{}
 
 	// create the blocker
-	blocker, err := newTestBlocker("BlockSkylinks", api)
+	blocker, err := newTestBlocker("BlockHashes", api)
 	if err != nil {
 		panic(err)
 	}
@@ -84,28 +84,27 @@ func testBlockHashes(t *testing.T) {
 		}
 	}()
 
-	// create a list of 16 skylinks, where the 10th skylink is one that triggers
-	// an error to be thrown in skyd, this will ensure the blocker tries:
-	// - all skylinks in 1 batch
+	// create a list of 16 hashes, where the 10th hash is one that triggers an
+	// error to be thrown in skyd, this will ensure the blocker tries:
+	// - all hashes in 1 batch
 	// - a batch size of 10, which still fails
-	// - all skylinks in a batch size of 1, which returns the failing skylink
-	var skylinks []database.BlockedSkylink
+	// - all hashes in a batch size of 1, which returns the failing hash
+	var hashes []crypto.Hash
 	var i int
 	for ; i < 9; i++ {
-		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_%d", i)))
-		skylinks = append(skylinks, database.BlockedSkylink{Hash: hash})
+		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_hash_%d", i)))
+		hashes = append(hashes, hash)
 	}
 
-	// the last skylink before the failure should be the latest timestamp set,
+	// the last hash before the failure should be the latest timestamp set,
 	// so save this timestamp as an expected value for later
-	hash := crypto.HashBytes([]byte("throwerror"))
-	skylinks = append(skylinks, database.BlockedSkylink{Hash: hash})
+	hashes = append(hashes, crypto.HashBytes([]byte("throwerror")))
 	for ; i < 15; i++ {
-		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_%d", i)))
-		skylinks = append(skylinks, database.BlockedSkylink{Hash: hash})
+		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_hash_%d", i)))
+		hashes = append(hashes, hash)
 	}
 
-	blocked, failed, err := blocker.blockSkylinks(skylinks)
+	blocked, failed, err := blocker.blockHashes(hashes)
 	if err != nil {
 		t.Fatal("unexpected error thrown", err)
 	}

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -10,23 +10,25 @@ import (
 	"github.com/SkynetLabs/blocker/skyd"
 	"github.com/sirupsen/logrus"
 	"gitlab.com/NebulousLabs/errors"
+	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.sia.tech/siad/crypto"
 )
 
 // mockSkyd is a helper struct that implements the skyd API, all methods are
 // essentially a no-op except for 'BlockSkylinks' which keeps track of the
 // arguments with which it is called
 type mockSkyd struct {
-	BlockSkylinksReqs [][]string
+	BlockHashesReqs [][]string
 }
 
 // BlockSkylinks adds the given skylinks to the block list.
-func (api *mockSkyd) BlockSkylinks(skylinks []string) error {
-	api.BlockSkylinksReqs = append(api.BlockSkylinksReqs, skylinks)
+func (api *mockSkyd) BlockHashes(hashes []string) error {
+	api.BlockHashesReqs = append(api.BlockHashesReqs, hashes)
 
 	// check whether the caller expects an error to be thrown
-	for _, sl := range skylinks {
-		if sl == "throwerror" {
+	for _, h := range hashes {
+		if h == crypto.HashBytes([]byte("throwerror")).String() {
 			return errors.New(unableToUpdateBlocklistErrStr)
 		}
 	}
@@ -39,7 +41,7 @@ func (api *mockSkyd) IsSkydUp() bool {
 }
 
 // ResolveSkylink tries to resolve the given skylink to a V1 skylink.
-func (api *mockSkyd) ResolveSkylink(skylink string) (string, error) {
+func (api *mockSkyd) ResolveSkylink(skylink skymodules.Skylink) (skymodules.Skylink, error) {
 	return skylink, nil
 }
 
@@ -56,7 +58,7 @@ func TestBlocker(t *testing.T) {
 	}{
 		{
 			name: "BlockSkylinks",
-			test: testBlockSkylinks,
+			test: testBlockHashes,
 		},
 	}
 	for _, test := range tests {
@@ -64,8 +66,8 @@ func TestBlocker(t *testing.T) {
 	}
 }
 
-// testBlockSkylinks is a unit test that covers the 'blockSkylinks' method.
-func testBlockSkylinks(t *testing.T) {
+// testBlockHashes is a unit test that covers the 'blockHashes' method.
+func testBlockHashes(t *testing.T) {
 	// create a mock skyd api
 	api := &mockSkyd{}
 
@@ -90,14 +92,17 @@ func testBlockSkylinks(t *testing.T) {
 	var skylinks []database.BlockedSkylink
 	var i int
 	for ; i < 9; i++ {
-		skylinks = append(skylinks, database.BlockedSkylink{Skylink: fmt.Sprintf("skylink_%d", i)})
+		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_%d", i)))
+		skylinks = append(skylinks, database.BlockedSkylink{Hash: hash})
 	}
 
 	// the last skylink before the failure should be the latest timestamp set,
 	// so save this timestamp as an expected value for later
-	skylinks = append(skylinks, database.BlockedSkylink{Skylink: "throwerror"})
+	hash := crypto.HashBytes([]byte("throwerror"))
+	skylinks = append(skylinks, database.BlockedSkylink{Hash: hash})
 	for ; i < 15; i++ {
-		skylinks = append(skylinks, database.BlockedSkylink{Skylink: fmt.Sprintf("skylink_%d", i)})
+		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_%d", i)))
+		skylinks = append(skylinks, database.BlockedSkylink{Hash: hash})
 	}
 
 	blocked, failed, err := blocker.blockSkylinks(skylinks)
@@ -113,18 +118,18 @@ func testBlockSkylinks(t *testing.T) {
 	}
 
 	// assert 18 requests in total happen to skyd, batch size 100, 10 and 1
-	if len(api.BlockSkylinksReqs) != 18 {
-		t.Fatalf("unexpected amount of calls to Skyd block endpoint, %v != 18", len(api.BlockSkylinksReqs))
+	if len(api.BlockHashesReqs) != 18 {
+		t.Fatalf("unexpected amount of calls to Skyd block endpoint, %v != 18", len(api.BlockHashesReqs))
 	}
-	if len(api.BlockSkylinksReqs[0]) != 16 {
-		t.Fatalf("unexpected first batch size, %v != 16", len(api.BlockSkylinksReqs[0]))
+	if len(api.BlockHashesReqs[0]) != 16 {
+		t.Fatalf("unexpected first batch size, %v != 16", len(api.BlockHashesReqs[0]))
 	}
-	if len(api.BlockSkylinksReqs[1]) != 10 {
-		t.Fatalf("unexpected second batch size, %v != 10", len(api.BlockSkylinksReqs[1]))
+	if len(api.BlockHashesReqs[1]) != 10 {
+		t.Fatalf("unexpected second batch size, %v != 10", len(api.BlockHashesReqs[1]))
 	}
 	for r := 2; r < 18; r++ {
-		if len(api.BlockSkylinksReqs[r]) != 1 {
-			t.Fatalf("unexpected batch size for req %d, %v != 1", r, len(api.BlockSkylinksReqs[r]))
+		if len(api.BlockHashesReqs[r]) != 1 {
+			t.Fatalf("unexpected batch size for req %d, %v != 1", r, len(api.BlockHashesReqs[r]))
 		}
 	}
 }

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -12,7 +12,6 @@ import (
 	"gitlab.com/NebulousLabs/errors"
 	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.sia.tech/siad/crypto"
 )
 
 // mockSkyd is a helper struct that implements the skyd API, all methods are
@@ -28,7 +27,7 @@ func (api *mockSkyd) BlockHashes(hashes []string) error {
 
 	// check whether the caller expects an error to be thrown
 	for _, h := range hashes {
-		if h == crypto.HashBytes([]byte("throwerror")).String() {
+		if h == database.HashBytes([]byte("throwerror")).String() {
 			return errors.New(unableToUpdateBlocklistErrStr)
 		}
 	}
@@ -89,18 +88,18 @@ func testBlockHashes(t *testing.T) {
 	// - all hashes in 1 batch
 	// - a batch size of 10, which still fails
 	// - all hashes in a batch size of 1, which returns the failing hash
-	var hashes []crypto.Hash
+	var hashes []database.Hash
 	var i int
 	for ; i < 9; i++ {
-		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_hash_%d", i)))
+		hash := database.HashBytes([]byte(fmt.Sprintf("skylink_hash_%d", i)))
 		hashes = append(hashes, hash)
 	}
 
 	// the last hash before the failure should be the latest timestamp set,
 	// so save this timestamp as an expected value for later
-	hashes = append(hashes, crypto.HashBytes([]byte("throwerror")))
+	hashes = append(hashes, database.HashBytes([]byte("throwerror")))
 	for ; i < 15; i++ {
-		hash := crypto.HashBytes([]byte(fmt.Sprintf("skylink_hash_%d", i)))
+		hash := database.HashBytes([]byte(fmt.Sprintf("skylink_hash_%d", i)))
 		hashes = append(hashes, hash)
 	}
 

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -16,13 +16,13 @@ import (
 )
 
 // mockSkyd is a helper struct that implements the skyd API, all methods are
-// essentially a no-op except for 'BlockSkylinks' which keeps track of the
+// essentially a no-op except for 'BlockHashes' which keeps track of the
 // arguments with which it is called
 type mockSkyd struct {
 	BlockHashesReqs [][]string
 }
 
-// BlockSkylinks adds the given skylinks to the block list.
+// BlockHashes adds the given hashes to the block list.
 func (api *mockSkyd) BlockHashes(hashes []string) error {
 	api.BlockHashesReqs = append(api.BlockHashesReqs, hashes)
 

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -74,7 +74,7 @@ func testBlockHashes(t *testing.T) {
 	// create the blocker
 	blocker, err := newTestBlocker("BlockHashes", api)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	// defer a db close

--- a/database/database.go
+++ b/database/database.go
@@ -168,10 +168,6 @@ func (db *DB) CreateBlockedSkylink(ctx context.Context, skylink *BlockedSkylink)
 	if skylink.Hash == emptyHash {
 		return errors.New("unexpected blocked skylink, 'hash' is not set")
 	}
-	// Ensure the 'reported' skylink is always set
-	if skylink.Reported == "" {
-		return errors.New("unexpected blocked skylink, 'reported' is not set")
-	}
 
 	_, err := db.staticSkylinks.InsertOne(ctx, skylink)
 	if err != nil && strings.Contains(err.Error(), "E11000 duplicate key error collection") {

--- a/database/database.go
+++ b/database/database.go
@@ -415,7 +415,6 @@ func (db *DB) find(ctx context.Context, filter interface{},
 		return nil, nil
 	}
 	if err != nil {
-		panic(err)
 		return nil, err
 	}
 

--- a/database/database.go
+++ b/database/database.go
@@ -455,6 +455,11 @@ func (db *DB) findOne(ctx context.Context, filter interface{},
 // updateFailedFlag is a helper method that updates the failed flag on the
 // documents that correspond with the skylinks in the given array.
 func (db *DB) updateFailedFlag(hashes []crypto.Hash, failed bool) error {
+	// return early if no hashes were given
+	if len(hashes) == 0 {
+		return nil
+	}
+
 	// create the filter, make sure to specify currently unblocked skylinks
 	filter := bson.M{
 		"hash":   bson.M{"$in": hashes},

--- a/database/database.go
+++ b/database/database.go
@@ -64,9 +64,6 @@ var (
 	collAllowlist = "allowlist"
 	// collLatestBlockTimestamps collLatestBlockTimestamps
 	collLatestBlockTimestamps = "latest_block_timestamps"
-
-	// emptyHash is a helper to compare against an empty hash
-	emptyHash = crypto.Hash{}
 )
 
 // DB holds a connection to the database, as well as helpful shortcuts to
@@ -171,7 +168,7 @@ func (db *DB) Close() error {
 // does nothing.
 func (db *DB) CreateBlockedSkylink(ctx context.Context, skylink *BlockedSkylink) error {
 	// Ensure the hash is set
-	if skylink.Hash == emptyHash {
+	if skylink.Hash == (crypto.Hash{}) {
 		return errors.New("unexpected blocked skylink, 'hash' is not set")
 	}
 
@@ -261,7 +258,7 @@ func (db *DB) HashesToBlock() ([]crypto.Hash, error) {
 	// Push cutoff one hour into the past in order to compensate of any
 	// potential system time drift.
 	cutoff = cutoff.Add(-time.Hour)
-	db.staticLogger.Tracef("SkylinksToBlock: fetching all skylinks added after cutoff of %s", cutoff.String())
+	db.staticLogger.Tracef("HashesToBlock: fetching all hashes added after cutoff of %s", cutoff.String())
 
 	filter := bson.M{
 		"timestamp_added": bson.M{"$gt": cutoff},
@@ -357,7 +354,7 @@ func (db *DB) compatTransformSkylinkToHash(ctx context.Context) error {
 		bson.D{{"$or", []interface{}{
 			bson.D{{"hash", nil}},
 			bson.D{{"hash", bson.M{"$exists": false}}},
-			bson.D{{"hash", emptyHash}},
+			bson.D{{"hash", crypto.Hash{}}},
 		}}},
 	}}}
 
@@ -398,7 +395,7 @@ func (db *DB) compatTransformSkylinkToHash(ctx context.Context) error {
 			bson.D{{"$or", []interface{}{
 				bson.D{{"hash", nil}},
 				bson.D{{"hash", bson.M{"$exists": false}}},
-				bson.D{{"hash", emptyHash}},
+				bson.D{{"hash", crypto.Hash{}}},
 			}}},
 		}}}
 		value := bson.M{"$set": bson.M{"hash": crypto.Hash(sl.MerkleRoot())}}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.sia.tech/siad/crypto"
 )
 
 // newTestDB creates a new database for a given test's name.
@@ -27,7 +29,12 @@ func newTestDB(ctx context.Context, dbName string) *DB {
 	if err != nil {
 		panic(err)
 	}
-	if err := db.staticSkylinks.Drop(ctx); err != nil {
+	_, err = db.staticSkylinks.DeleteMany(ctx, bson.D{})
+	if err != nil {
+		panic(err)
+	}
+	_, err = db.staticAllowList.DeleteMany(ctx, bson.D{})
+	if err != nil {
 		panic(err)
 	}
 	return db
@@ -63,6 +70,10 @@ func TestDatabase(t *testing.T) {
 		{
 			name: "MarkAsFailed",
 			test: testMarkAsFailed,
+		},
+		{
+			name: "compatTransformSkylinkToHash",
+			test: testCompatTransformSkylinkToHash,
 		},
 	}
 	for _, test := range tests {
@@ -108,6 +119,7 @@ func testCreateBlockedSkylink(t *testing.T) {
 	now := time.Now().Round(time.Second).UTC()
 	sl := &BlockedSkylink{
 		Skylink: "somelink",
+		Hash:    crypto.HashBytes([]byte("somelink")),
 		Reporter: Reporter{
 			Name:            "name",
 			Email:           "email",
@@ -127,7 +139,7 @@ func testCreateBlockedSkylink(t *testing.T) {
 	}
 
 	// Fetch it again.
-	fetchedSL, err := db.BlockedSkylink(ctx, sl.Skylink)
+	fetchedSL, err := db.FindBySkylink(ctx, sl.Skylink)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +272,7 @@ func testMarkAsFailed(t *testing.T) {
 	})
 
 	// fetch a cursor that holds all docs
-	c, err := db.staticDB.Collection(dbSkylinks).Find(db.ctx, bson.M{})
+	c, err := db.staticDB.Collection(collSkylinks).Find(db.ctx, bson.M{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,4 +309,129 @@ func testMarkAsFailed(t *testing.T) {
 	}
 
 	// no need to mark them as succeeded, the other unit test covers that
+}
+
+// testCompatTransformSkylinkToHash is a unit test that verifies the correct
+// execution of the 'compatTransformSkylinkToHash' method on the database.
+func testCompatTransformSkylinkToHash(t *testing.T) {
+	// create context
+	ctx, cancel := context.WithTimeout(context.Background(), mongoDefaultTimeout)
+	defer cancel()
+
+	// create test database
+	db := newTestDB(ctx, t.Name())
+	defer db.Close()
+
+	// define a helper function to count the number of documents that the compat
+	// code should run on
+	countOldDocs := func() int {
+		// find all documents where the skyink has to be transformed to a hash
+		docs, err := db.find(ctx, bson.D{{"$and", []interface{}{
+			bson.D{{"skylink", bson.M{"$exists": true}}},
+			bson.D{{"$or", []interface{}{
+				bson.D{{"hash", nil}},
+				bson.D{{"hash", bson.M{"$exists": false}}},
+				bson.D{{"hash", emptyHash}},
+			}}},
+		}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(docs)
+	}
+
+	// define a helper function to decode a skylink as string into a skylink obj
+	skylinkFromString := func(skylink string) (sl skymodules.Skylink) {
+		err := sl.LoadString(skylink)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	// assert the number of 'old' docs is 0
+	numOld := countOldDocs()
+	if numOld != 0 {
+		t.Fatalf("unexpected amount of docs, %v != 0", numOld)
+	}
+
+	// run the compat code on an empty database
+	err := db.compatTransformSkylinkToHash(ctx)
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	// prepare 3 skylinks
+	sl1 := skylinkFromString("BAAWi3ou51qCH24Im0ESS-5_gKg60qGIYtta-ryrl1kBnQ")
+	sl2 := skylinkFromString("IABst6HgaJ0PIBMtmQ2qgH_wQlFg4bNnwAhff7DmJP6oyg")
+	sl3 := skylinkFromString("IABXaRBvjDTB3RizX3RfwdCoxt2Tff1buEXhlO7b9Unn8g")
+
+	// insert two documents with a skylink but no hash (like it was originally)
+	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{
+		Skylink:        sl1.String(),
+		Reporter:       Reporter{},
+		Tags:           []string{"tag_1"},
+		TimestampAdded: time.Now().UTC(),
+	})
+	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{
+		Skylink:        sl2.String(),
+		Reporter:       Reporter{},
+		Tags:           []string{"tag_1"},
+		TimestampAdded: time.Now().Add(time.Minute).UTC(),
+	})
+
+	// insert one documents with a skylink and a hash
+	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{
+		Skylink:        sl3.String(),
+		Hash:           crypto.Hash(sl3.MerkleRoot()),
+		Reporter:       Reporter{},
+		Tags:           []string{"tag_1"},
+		TimestampAdded: time.Now().Add(time.Hour).UTC(),
+	})
+
+	// assert the number of 'old' docs is 2
+	numOld = countOldDocs()
+	if numOld != 2 {
+		t.Fatalf("unexpected amount of docs, %v != 2", numOld)
+	}
+
+	// run the compat code again
+	err = db.compatTransformSkylinkToHash(ctx)
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	// find all skylink documents, in order
+	opts := options.Find()
+	opts.SetSort(bson.D{{"timestamp_added", 1}})
+	skylinks, err := db.find(ctx, bson.D{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skylinks) != 3 {
+		t.Fatalf("unexpected amount of docs, %v != 3", len(skylinks))
+	}
+
+	// assert the skylink and hash value for all documents
+	sl11 := skylinkFromString(skylinks[0].Skylink)
+	if sl11.String() != sl1.String() {
+		t.Fatal("unexpected skylink value")
+	}
+	if crypto.Hash(sl11.MerkleRoot()) != skylinks[0].Hash {
+		t.Fatal("unexpected hash value", crypto.Hash(sl11.MerkleRoot()), skylinks[0].Hash)
+	}
+	sl22 := skylinkFromString(skylinks[1].Skylink)
+	if sl22.String() != sl2.String() {
+		t.Fatal("unexpected skylink value")
+	}
+	if crypto.Hash(sl22.MerkleRoot()) != skylinks[1].Hash {
+		t.Fatal("unexpected hash value")
+	}
+	sl33 := skylinkFromString(skylinks[2].Skylink)
+	if sl33.String() != sl3.String() {
+		t.Fatal("unexpected skylink value")
+	}
+	if crypto.Hash(sl33.MerkleRoot()) != skylinks[2].Hash {
+		t.Fatal("unexpected hash value")
+	}
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -228,6 +228,13 @@ func testMarkAsSucceeded(t *testing.T) {
 	db := newTestDB(ctx, t.Name())
 	defer db.Close()
 
+	// ensure 'MarkAsSucceeded' can handle an empty slice
+	var empty []crypto.Hash
+	err := db.MarkAsSucceeded(empty)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// insert a regular document and one that was marked as failed
 	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{
 		Skylink:        "skylink_1",
@@ -277,6 +284,13 @@ func testMarkAsFailed(t *testing.T) {
 	// create test database
 	db := newTestDB(ctx, t.Name())
 	defer db.Close()
+
+	// ensure 'MarkAsFailed' can handle an empty slice
+	var empty []crypto.Hash
+	err := db.MarkAsFailed(empty)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// insert two regular documents
 	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -372,22 +372,13 @@ func testCompatTransformSkylinkToHash(t *testing.T) {
 			bson.D{{"$or", []interface{}{
 				bson.D{{"hash", nil}},
 				bson.D{{"hash", bson.M{"$exists": false}}},
-				bson.D{{"hash", emptyHash}},
+				bson.D{{"hash", crypto.Hash{}}},
 			}}},
 		}}})
 		if err != nil {
 			t.Fatal(err)
 		}
 		return len(docs)
-	}
-
-	// define a helper function to decode a skylink as string into a skylink obj
-	skylinkFromString := func(skylink string) (sl skymodules.Skylink) {
-		err := sl.LoadString(skylink)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return
 	}
 
 	// assert the number of 'old' docs is 0
@@ -475,4 +466,13 @@ func testCompatTransformSkylinkToHash(t *testing.T) {
 	if crypto.Hash(sl33.MerkleRoot()) != skylinks[2].Hash {
 		t.Fatal("unexpected hash value")
 	}
+}
+
+// define a helper function to decode a skylink as string into a skylink obj
+func skylinkFromString(skylink string) (sl skymodules.Skylink) {
+	err := sl.LoadString(skylink)
+	if err != nil {
+		panic(err)
+	}
+	return
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -115,18 +115,13 @@ func testCreateBlockedSkylink(t *testing.T) {
 	db := newTestDB(ctx, t.Name())
 	defer db.Close()
 
-	// Verify we assert both 'Hash' and 'Reported' properties are set
+	// Verify we assert 'Hash' is set
 	err := db.CreateBlockedSkylink(ctx, &BlockedSkylink{})
 	if err == nil || !strings.Contains(err.Error(), "'hash' is not set") {
 		t.Fatal("expected 'hash is not set' error", err)
 	}
-	err = db.CreateBlockedSkylink(ctx, &BlockedSkylink{Hash: crypto.HashBytes([]byte("somehash"))})
-	if err == nil || !strings.Contains(err.Error(), "'reported' is not set") {
-		t.Fatal("expected 'reported is not set' error", err)
-	}
 	err = db.CreateBlockedSkylink(ctx, &BlockedSkylink{
-		Hash:     crypto.HashBytes([]byte("somehash")),
-		Reported: "someskylink",
+		Hash: crypto.HashBytes([]byte("somehash")),
 	})
 	if err != nil {
 		t.Fatal("unexpected error", err)
@@ -135,8 +130,7 @@ func testCreateBlockedSkylink(t *testing.T) {
 	// Create skylink to block.
 	now := time.Now().Round(time.Second).UTC()
 	sl := &BlockedSkylink{
-		Hash:     crypto.HashBytes([]byte("somelink")),
-		Reported: "somelink",
+		Hash: crypto.HashBytes([]byte("somelink")),
 		Reporter: Reporter{
 			Name:            "name",
 			Email:           "email",

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -19,7 +19,7 @@ type Hash struct {
 
 // NewHash returns the Hash of the given skylink.
 func NewHash(sl skymodules.Skylink) Hash {
-	return Hash{crypto.Hash(sl.MerkleRoot())}
+	return Hash{crypto.HashObject(sl.MerkleRoot())}
 }
 
 // HashBytes returns the Hash of the given bytes.

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -3,8 +3,8 @@ package database
 import (
 	"time"
 
-	"go.sia.tech/siad/crypto"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.sia.tech/siad/crypto"
 )
 
 // AllowListedSkylink is a skylink that is allow listed and thus prohibited from
@@ -17,14 +17,19 @@ type AllowListedSkylink struct {
 }
 
 // BlockedSkylink is a skylink blocked by an external request.
+//
+// NOTE: Reported contains the originally reported/blocked Skylink, this field
+// can differ from the Skylink if a v2 Skylink was reported, in that case the
+// Skylink property would contain the resolved v1 Skylink
 type BlockedSkylink struct {
 	ID                primitive.ObjectID `bson:"_id,omitempty"`
-	Skylink           string             `bson:"skylink"`
+	Failed            bool               `bson:"failed"`
 	Hash              crypto.Hash        `bson:"hash"`
+	Reported          string             `bson:"reported"`
 	Reporter          Reporter           `bson:"reporter"`
 	Reverted          bool               `bson:"reverted"`
-	Failed            bool               `bson:"failed"`
 	RevertedTags      []string           `bson:"reverted_tags"`
+	Skylink           string             `bson:"skylink"`
 	Tags              []string           `bson:"tags"`
 	TimestampAdded    time.Time          `bson:"timestamp_added"`
 	TimestampReverted time.Time          `bson:"timestamp_reverted"`

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -17,15 +17,10 @@ type AllowListedSkylink struct {
 }
 
 // BlockedSkylink is a skylink blocked by an external request.
-//
-// NOTE: Reported contains the originally reported/blocked Skylink, this field
-// can differ from the Skylink if a v2 Skylink was reported, in that case the
-// Skylink property would contain the resolved v1 Skylink
 type BlockedSkylink struct {
 	ID                primitive.ObjectID `bson:"_id,omitempty"`
 	Failed            bool               `bson:"failed"`
 	Hash              crypto.Hash        `bson:"hash"`
-	Reported          string             `bson:"reported"`
 	Reporter          Reporter           `bson:"reporter"`
 	Reverted          bool               `bson:"reverted"`
 	RevertedTags      []string           `bson:"reverted_tags"`

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -1,11 +1,52 @@
 package database
 
 import (
+	"fmt"
 	"time"
 
+	"gitlab.com/SkynetLabs/skyd/skymodules"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.sia.tech/siad/crypto"
 )
+
+// Hash is a struct that embeds the crypto.Hash, allowing us to implement the
+// bsoncodec ValueMarshaler interfaces.
+type Hash struct {
+	crypto.Hash
+}
+
+// NewHash returns the Hash of the given skylink.
+func NewHash(sl skymodules.Skylink) Hash {
+	return Hash{crypto.Hash(sl.MerkleRoot())}
+}
+
+// HashBytes returns the Hash of the given bytes.
+func HashBytes(b []byte) Hash {
+	return Hash{crypto.HashBytes(b)}
+}
+
+// MarshalBSONValue implements the bsoncodec.ValueMarshaler interface.
+func (h Hash) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	return bsontype.String, bsoncore.AppendString(nil, h.String()), nil
+}
+
+// UnmarshalBSONValue implements the bsoncodec.ValueUnmarshaler interface.
+func (h *Hash) UnmarshalBSONValue(t bsontype.Type, b []byte) error {
+	s, _, ok := bsoncore.ReadString(b)
+	if !ok {
+		return fmt.Errorf("Hash UnmarshalBSONValue error, reading '%s'", string(b))
+	}
+
+	var unmarshaled Hash
+	err := unmarshaled.LoadString(s)
+	if err != nil {
+		return err
+	}
+	*h = unmarshaled
+	return nil
+}
 
 // AllowListedSkylink is a skylink that is allow listed and thus prohibited from
 // ever being blocked.
@@ -20,7 +61,7 @@ type AllowListedSkylink struct {
 type BlockedSkylink struct {
 	ID                primitive.ObjectID `bson:"_id,omitempty"`
 	Failed            bool               `bson:"failed"`
-	Hash              crypto.Hash        `bson:"hash"`
+	Hash              Hash               `bson:"hash"`
 	Reporter          Reporter           `bson:"reporter"`
 	Reverted          bool               `bson:"reverted"`
 	RevertedTags      []string           `bson:"reverted_tags"`

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -3,6 +3,7 @@ package database
 import (
 	"time"
 
+	"go.sia.tech/siad/crypto"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -19,6 +20,7 @@ type AllowListedSkylink struct {
 type BlockedSkylink struct {
 	ID                primitive.ObjectID `bson:"_id,omitempty"`
 	Skylink           string             `bson:"skylink"`
+	Hash              crypto.Hash        `bson:"hash"`
 	Reporter          Reporter           `bson:"reporter"`
 	Reverted          bool               `bson:"reverted"`
 	Failed            bool               `bson:"failed"`

--- a/database/skylink_test.go
+++ b/database/skylink_test.go
@@ -1,0 +1,55 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.sia.tech/siad/crypto"
+)
+
+// testObject is a helper struct that contains a Hash
+type testObject struct {
+	Hash Hash `bson:"hash"`
+}
+
+// TestHashMarhsaling is a small unit test that verifies whether a Hash is
+// properly marshaled and unmarshaled when inserted or fetched from the database
+func TestHashMarhsaling(t *testing.T) {
+	// create context
+	ctx, cancel := context.WithTimeout(context.Background(), MongoDefaultTimeout)
+	defer cancel()
+
+	// create test database
+	db := newTestDB(ctx, t.Name())
+	defer db.Close()
+
+	// create test collection and purge it
+	coll := db.staticDB.Collection(t.Name())
+	_, err := coll.DeleteMany(ctx, bson.M{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// insert a test object
+	hash := Hash{crypto.HashBytes([]byte("helloworld"))}
+	_, err = coll.InsertOne(ctx, &testObject{Hash: hash})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// find the test object and decode it
+	var um testObject
+	err = coll.FindOne(ctx, bson.M{}).Decode(&um)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's identical
+	if um.Hash == (Hash{}) {
+		t.Fatal("unmarshaled hash should not be empty")
+	}
+	if um.Hash.String() != hash.String() {
+		t.Fatal("unmarshaled hash is not identical to original hash")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -73,9 +73,6 @@ func main() {
 	logger.SetLevel(logLevel)
 
 	// Set the unique name of this server.
-	//
-	// TODO: it might make sense to rename this to SERVER_NAME, SERVER_DOMAIN
-	// might not make sense in a single portal type setup
 	database.ServerDomain = os.Getenv("SERVER_DOMAIN")
 	if database.ServerDomain == "" {
 		log.Fatal("missing env var SERVER_DOMAIN")

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/SkynetLabs/blocker/api"
 	"github.com/SkynetLabs/blocker/blocker"
@@ -73,15 +72,10 @@ func main() {
 	}
 	logger.SetLevel(logLevel)
 
-	// Set the preferred portal address.
-	database.Portal = os.Getenv("PORTAL_DOMAIN")
-	if database.Portal == "" {
-		log.Fatal("missing env var PORTAL_DOMAIN")
-	}
-	if !strings.HasPrefix(database.Portal, "http") {
-		database.Portal = "https://" + database.Portal
-	}
 	// Set the unique name of this server.
+	//
+	// TODO: it might make sense to rename this to SERVER_NAME, SERVER_DOMAIN
+	// might not make sense in a single portal type setup
 	database.ServerDomain = os.Getenv("SERVER_DOMAIN")
 	if database.ServerDomain == "" {
 		log.Fatal("missing env var SERVER_DOMAIN")


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR is a refactor that makes the `blocker` module handle hashes instead of skylinks. This is important as it is a first step towards removing all (abusive) skylinks from our database and log files. If we keep storing these abusive skylinks, we are essentially keeping a database of abuse.

As the title mentions, this is part one of a two-step refactor. Currently, there's a unique index on the `skylink` property, which should be replaced by a unique index on the `hash` property. The easiest way to accomplish this is to use a two-step deployment.

The first step, this one, will:
- add a `hash` field and populate it
- convert the codebase to work solely with hashes

The second step will:
- add a unique index on the `hash` field
- remove the index constraint on the `skylink` field
- remove the `skylink` field all together

After we deploy the second step, we can manually run a query on the database that removes all `skylink` properties from all documents. This is by far the easiest solution in my opinion. It has numerous benefits, like the option to roll back in case of a mistake being made.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods

## Issues Closed
N/A