### PR TITLE
Server UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,5 @@ This service depends on the following environment variables:
 * `SKYNET_DB_PASS`
 * `SKYNET_ACCOUNTS_HOST`, defaults to `accounts`
 * `SKYNET_ACCOUNTS_PORT`, defaults to `3000`
-* `SERVER_DOMAIN`, e.g. `eu-ger-5.siasky.net`
-* `PORTAL_DOMAIN`, e.g. `siasky.net`
+* `SERVER_UID`, e.g. `94743e8e2673a176`
 * `BLOCKER_LOG_LEVEL`, defaults to `info`
-
-## Blocker Identifier
-
-The blocker requires a unique identifier because the blocker keeps a state
-variable that indicates which hashes have been blocked on the local skyd
-instance. All blocker modules work off of the same database, but every server
-has to keep track of what hashes have been blocked already.
-
-In a multi-server setup, this should be configured through the `SERVER_DOMAIN`
-environment variable. In a single-server setup however, the `SERVER_DOMAIN`
-environment variable is not set, in which case we fall back to using the
-`PORTAL_DOMAIN` environemnt variable as a unique identifier.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ This service depends on the following environment variables:
 
 ## Blocker Identifier
 
-For the blocker module to work properly, it must have a unique identifier. In a
-multi-server setup, this should be configured through the `SERVER_DOMAIN`
-environemnt variable. In a single-server setup however, the `SERVER_DOMAIN`
-environment variable is not set, in that case the blocker will fall back to
-using the `PORTAL_DOMAIN` as a unique identifier for the blocker module.
+The blocker requires a unique identifier because the blocker keeps a state
+variable that indicates which hashes have been blocked on the local skyd
+instance. All blocker modules work off of the same database, but every server
+has to keep track of what hashes have been blocked already.
+
+In a multi-server setup, this should be configured through the `SERVER_DOMAIN`
+environment variable. In a single-server setup however, the `SERVER_DOMAIN`
+environment variable is not set, in which case we fall back to using the
+`PORTAL_DOMAIN` environemnt variable as a unique identifier.

--- a/README.md
+++ b/README.md
@@ -26,15 +26,23 @@ So that's without portal and without the `sia://` prefix.
 # Environment
 
 This service depends on the following environment variables:
-* `PORTAL_DOMAIN`, e.g. `siasky.net`
 * `API_HOST`, e.g. `sia` (defaults to `sia`)
 * `API_PORT`, e.g. `9980` (defaults to `9980`)
 * `SIA_API_PASSWORD`
-* `SERVER_DOMAIN`, e.g. `eu-ger-5.siasky.net`
-* `BLOCKER_LOG_LEVEL`, defaults to `info`
 * `SKYNET_DB_HOST`
 * `SKYNET_DB_PORT`
 * `SKYNET_DB_USER`
 * `SKYNET_DB_PASS`
 * `SKYNET_ACCOUNTS_HOST`, defaults to `accounts`
 * `SKYNET_ACCOUNTS_PORT`, defaults to `3000`
+* `SERVER_DOMAIN`, e.g. `eu-ger-5.siasky.net`
+* `PORTAL_DOMAIN`, e.g. `siasky.net`
+* `BLOCKER_LOG_LEVEL`, defaults to `info`
+
+## Blocker Identifier
+
+For the blocker module to work properly, it must have a unique identifier. In a
+multi-server setup, this should be configured through the `SERVER_DOMAIN`
+environemnt variable. In a single-server setup however, the `SERVER_DOMAIN`
+environment variable is not set, in that case the blocker will fall back to
+using the `PORTAL_DOMAIN` as a unique identifier for the blocker module.

--- a/database/database.go
+++ b/database/database.go
@@ -42,11 +42,8 @@ var (
 	// and it already exists there.
 	ErrSkylinkExists = errors.New("skylink already exists")
 
-	// ServerDomain is the unique server name, e.g. eu-pol-4.siasky.net
-	//
-	// NOTE: this variable is set to the SERVER_DOMAIN environment variable if
-	// present, if not it fall backs to the PORTAL_DOMAIN environment variable
-	ServerDomain string
+	// ServerUID is a random 16-char string that uniquely identifies the server
+	ServerUID string
 
 	// True is a helper value, so we can pass a *bool to MongoDB's methods.
 	True = true
@@ -273,7 +270,7 @@ func (db *DB) SkylinksToRetry() ([]BlockedSkylink, error) {
 // skylink that was blocked. When fetching new SkylinksToBlock we should start
 // from that timestamp (and one hour before that).
 func (db *DB) LatestBlockTimestamp() (time.Time, error) {
-	sr := db.staticDB.Collection(dbLatestBlockTimestamps).FindOne(db.ctx, bson.M{"server_name": ServerDomain})
+	sr := db.staticDB.Collection(dbLatestBlockTimestamps).FindOne(db.ctx, bson.M{"server_name": ServerUID})
 	if sr.Err() != nil && sr.Err() != mongo.ErrNoDocuments {
 		return time.Time{}, sr.Err()
 	}
@@ -294,8 +291,8 @@ func (db *DB) LatestBlockTimestamp() (time.Time, error) {
 // skylink that was blocked. When fetching new SkylinksToBlock we should start
 // from that timestamp (and one hour before that).
 func (db *DB) SetLatestBlockTimestamp(t time.Time) error {
-	filter := bson.M{"server_name": ServerDomain}
-	value := bson.M{"$set": bson.M{"server_name": ServerDomain, "latest_block": t}}
+	filter := bson.M{"server_name": ServerUID}
+	value := bson.M{"$set": bson.M{"server_name": ServerUID, "latest_block": t}}
 	opts := options.UpdateOptions{Upsert: &True}
 	ur, err := db.staticDB.Collection(dbLatestBlockTimestamps).UpdateOne(db.ctx, filter, value, &opts)
 	if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -42,7 +42,7 @@ var (
 	// and it already exists there.
 	ErrSkylinkExists = errors.New("skylink already exists")
 
-	// ServerUID is a random 16-char string that uniquely identifies the server
+	// ServerUID is a random string that uniquely identifies the server
 	ServerUID string
 
 	// True is a helper value, so we can pass a *bool to MongoDB's methods.

--- a/database/database.go
+++ b/database/database.go
@@ -42,9 +42,10 @@ var (
 	// and it already exists there.
 	ErrSkylinkExists = errors.New("skylink already exists")
 
-	// Portal is the preferred portal to use, e.g. https://siasky.net
-	Portal string
 	// ServerDomain is the unique server name, e.g. eu-pol-4.siasky.net
+	//
+	// NOTE: this variable is set to the SERVER_DOMAIN environment variable if
+	// present, if not it fall backs to the PORTAL_DOMAIN environment variable
 	ServerDomain string
 
 	// True is a helper value, so we can pass a *bool to MongoDB's methods.

--- a/main.go
+++ b/main.go
@@ -72,14 +72,10 @@ func main() {
 	}
 	logger.SetLevel(logLevel)
 
-	// Set the unique name of this server. If SERVER_DOMAIN is net present,
-	// which is possible in a single-server setup, the PORTAL_DOMAIN is used.
-	database.ServerDomain = os.Getenv("SERVER_DOMAIN")
-	if database.ServerDomain == "" {
-		database.ServerDomain = os.Getenv("PORTAL_DOMAIN")
-		if database.ServerDomain == "" {
-			log.Fatal("missing unique server name, configure either SERVER_DOMAIN or PORTAL_DOMAIN (as fall back)")
-		}
+	// Set the unique id of this server.
+	database.ServerUID = os.Getenv("SERVER_UID")
+	if database.ServerUID == "" {
+		log.Fatal("missing env var SERVER_UID")
 	}
 
 	// Initialised the database connection.

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/SkynetLabs/blocker/api"
 	"github.com/SkynetLabs/blocker/blocker"
@@ -73,18 +72,14 @@ func main() {
 	}
 	logger.SetLevel(logLevel)
 
-	// Set the preferred portal address.
-	database.Portal = os.Getenv("PORTAL_DOMAIN")
-	if database.Portal == "" {
-		log.Fatal("missing env var PORTAL_DOMAIN")
-	}
-	if !strings.HasPrefix(database.Portal, "http") {
-		database.Portal = "https://" + database.Portal
-	}
-	// Set the unique name of this server.
+	// Set the unique name of this server. If SERVER_DOMAIN is net present,
+	// which is possible in a single-server setup, the PORTAL_DOMAIN is used.
 	database.ServerDomain = os.Getenv("SERVER_DOMAIN")
 	if database.ServerDomain == "" {
-		log.Fatal("missing env var SERVER_DOMAIN")
+		database.ServerDomain = os.Getenv("PORTAL_DOMAIN")
+		if database.ServerDomain == "" {
+			log.Fatal("missing unique server name, configure either SERVER_DOMAIN or PORTAL_DOMAIN (as fall back)")
+		}
 	}
 
 	// Initialised the database connection.


### PR DESCRIPTION
# PULL REQUEST

## Overview

In single server portal setups, the `SERVER_DOMAIN` environment variable is not present. This environment variable is used to uniquely define the blocker module. This PR changes that and from now on uses `SERVER_UID` which is an automatically generated unique identifier.

## NOTE

This is dependant on https://github.com/SkynetLabs/skynet-webportal/pull/1574

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings

## Issues Closed
N/A