### PR TITLE
include dockerfile and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.17.7 as builder
+LABEL maintainer="SkynetLabs <devs@skynetlabs.com>"
+
+WORKDIR /root
+
+COPY api api
+COPY blocker blocker
+COPY database database
+COPY skyd skyd
+COPY go.mod go.sum main.go Makefile ./
+
+RUN go mod download && make release
+
+FROM golang:1.17.7-alpine
+LABEL maintainer="SkynetLabs <devs@skynetlabs.com>"
+
+COPY --from=builder /go/bin/blocker /go/bin/blocker
+
+ENTRYPOINT ["blocker"]


### PR DESCRIPTION
- include Dockerfile (to enable docker hub builds)
- include dependabot config to make sure the image dependencies are up to date
- update golang image from 1.17.3 to 1.17.7
- introduced multi stage build - build with debian and copy binary to alpine image to reduce image size
- updated maintainer email address
- removed redundant GOOS and GOARCH env vars - those are golang image defaults anyway