### PR TITLE
Blocklist Endpoint

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -90,6 +90,9 @@ func (at *apiTester) blocklistGET(sort *string, offset, limit *int) (BlocklistGE
 		return BlocklistGET{}, err
 	}
 	var blg BlocklistGET
-	json.Unmarshal(data, &blg)
+	err = json.Unmarshal(data, &blg)
+	if err != nil {
+		return BlocklistGET{}, err
+	}
 	return blg, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -84,8 +84,8 @@ func (at *apiTester) blocklistGET(sort *string, offset, limit *int) (BlocklistGE
 }
 
 // get is a helper function that executes a GET request on the given endpoint
-// withe provided query values. It allows passing an object into which we'll
-// unmarshal the response body
+// with the provided query values. The response will get unmarshaled into the
+// given response object.
 func (at *apiTester) get(endpoint string, query url.Values, obj interface{}) error {
 	// create the request
 	url := fmt.Sprintf("%s?%s", endpoint, query.Encode())
@@ -104,7 +104,7 @@ func (at *apiTester) get(endpoint string, query url.Values, obj interface{}) err
 	}
 
 	// return an error if the status code is not in the 200s
-	if res.StatusCode >= 300 {
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return fmt.Errorf("GET request to '%s' with status %d, response body: %v", endpoint, res.StatusCode, string(data))
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	url "net/url"
+
+	"github.com/SkynetLabs/blocker/database"
+	"github.com/SkynetLabs/blocker/skyd"
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// apiTester is a helper struct wrapping handlers of the underlying API that
+// record a certain request and parse the API response.
+type apiTester struct {
+	staticAPI *API
+}
+
+// newAPITester returns a new instance of apiTester
+func newAPITester(api *API) *apiTester {
+	return &apiTester{staticAPI: api}
+}
+
+// newTestAPI returns a new API instance
+func newTestAPI(dbName string, skyd skyd.API) (*API, error) {
+	// create a nil logger
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	// create database
+	db, err := database.NewCustomDB(context.Background(), "mongodb://localhost:37017", dbName, options.Credential{
+		Username: "admin",
+		Password: "aO4tV5tC1oU3oQ7u",
+	}, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+	defer cancel()
+
+	// purge the database
+	err = db.Purge(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// create the API
+	api, err := New(skyd, db, logger)
+	if err != nil {
+		return nil, err
+	}
+	return api, nil
+}
+
+// blocklistGET records an api call to GET /blocklist on the underlying API
+// using the given parameters and returns a parsed response.
+func (*apiTester) blocklistGET(api *API, sort *string, offset, limit *int) (BlocklistGET, error) {
+	// set url values
+	values := url.Values{}
+	if offset != nil {
+		values.Set("offset", fmt.Sprint(*offset))
+	}
+	if limit != nil {
+		values.Set("limit", fmt.Sprint(*limit))
+	}
+	if sort != nil {
+		values.Set("sort", *sort)
+	}
+
+	// create the request
+	url := fmt.Sprintf("/blocklist?%s", values.Encode())
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+
+	// create a recorder and execute the request
+	w := httptest.NewRecorder()
+	api.blocklistGET(w, req, nil)
+	res := w.Result()
+	defer res.Body.Close()
+
+	// handle the response
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return BlocklistGET{}, err
+	}
+	var blg BlocklistGET
+	json.Unmarshal(data, &blg)
+	return blg, nil
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -61,7 +61,7 @@ func newTestAPI(dbName string, skyd skyd.API) (*API, error) {
 
 // blocklistGET records an api call to GET /blocklist on the underlying API
 // using the given parameters and returns a parsed response.
-func (*apiTester) blocklistGET(api *API, sort *string, offset, limit *int) (BlocklistGET, error) {
+func (at *apiTester) blocklistGET(sort *string, offset, limit *int) (BlocklistGET, error) {
 	// set url values
 	values := url.Values{}
 	if offset != nil {
@@ -80,7 +80,7 @@ func (*apiTester) blocklistGET(api *API, sort *string, offset, limit *int) (Bloc
 
 	// create a recorder and execute the request
 	w := httptest.NewRecorder()
-	api.blocklistGET(w, req, nil)
+	at.staticAPI.blocklistGET(w, req, nil)
 	res := w.Result()
 	defer res.Body.Close()
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -104,7 +104,7 @@ func (at *apiTester) get(endpoint string, query url.Values, obj interface{}) err
 	}
 
 	// return an error if the status code is not in the 200s
-	if res.StatusCode > 300 {
+	if res.StatusCode >= 300 {
 		return fmt.Errorf("GET request to '%s' with status %d, response body: %v", endpoint, res.StatusCode, string(data))
 	}
 

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -5,19 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	url "net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/SkynetLabs/blocker/database"
-	"github.com/SkynetLabs/blocker/skyd"
-	"github.com/sirupsen/logrus"
 	"gitlab.com/SkynetLabs/skyd/skymodules"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 var (
@@ -237,9 +232,10 @@ func testHandleBlocklistGET(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	apiTester := newAPITester(api)
 
 	// fetch the blocklist and assert it is empty
-	bl, err := fetchBlocklist(api, nil, nil, nil)
+	bl, err := apiTester.blocklistGET(api, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +266,7 @@ func testHandleBlocklistGET(t *testing.T) {
 	}
 
 	// assert base case
-	bl, err = fetchBlocklist(api, nil, nil, nil)
+	bl, err = apiTester.blocklistGET(api, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +285,7 @@ func testHandleBlocklistGET(t *testing.T) {
 
 	// assert limit of 1
 	limit := 1
-	bl, err = fetchBlocklist(api, nil, nil, &limit)
+	bl, err = apiTester.blocklistGET(api, nil, nil, &limit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +298,7 @@ func testHandleBlocklistGET(t *testing.T) {
 
 	// assert offset of 1
 	offset := 1
-	bl, err = fetchBlocklist(api, nil, &offset, nil)
+	bl, err = apiTester.blocklistGET(api, nil, &offset, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +314,7 @@ func testHandleBlocklistGET(t *testing.T) {
 
 	// assert sort
 	sort := "desc"
-	bl, err = fetchBlocklist(api, &sort, nil, nil)
+	bl, err = apiTester.blocklistGET(api, &sort, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,7 +337,7 @@ func testHandleBlocklistGET(t *testing.T) {
 	hasmore := true
 	var entries []BlockedHash
 	for hasmore {
-		bl, err = fetchBlocklist(api, nil, &offset, &limit)
+		bl, err = apiTester.blocklistGET(api, nil, &offset, &limit)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -433,71 +429,4 @@ func TestVerifySkappReport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-// newTestAPI returns a new API instance
-func newTestAPI(dbName string, skyd skyd.API) (*API, error) {
-	// create a nil logger
-	logger := logrus.New()
-	logger.Out = ioutil.Discard
-
-	// create database
-	db, err := database.NewCustomDB(context.Background(), "mongodb://localhost:37017", dbName, options.Credential{
-		Username: "admin",
-		Password: "aO4tV5tC1oU3oQ7u",
-	}, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	// create a context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
-	defer cancel()
-
-	// purge the database
-	err = db.Purge(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	// create the API
-	api, err := New(skyd, db, logger)
-	if err != nil {
-		return nil, err
-	}
-	return api, nil
-}
-
-// fetchBlocklist is a helper function that fetches the blocklist
-func fetchBlocklist(api *API, sort *string, offset, limit *int) (BlocklistGET, error) {
-	// set url values
-	values := url.Values{}
-	if offset != nil {
-		values.Set("offset", fmt.Sprint(*offset))
-	}
-	if limit != nil {
-		values.Set("limit", fmt.Sprint(*limit))
-	}
-	if sort != nil {
-		values.Set("sort", *sort)
-	}
-
-	// create the request
-	url := fmt.Sprintf("/blocklist?%s", values.Encode())
-	req := httptest.NewRequest(http.MethodGet, url, nil)
-
-	// create a recorder and execute the request
-	w := httptest.NewRecorder()
-	api.blocklistGET(w, req, nil)
-	res := w.Result()
-	defer res.Body.Close()
-
-	// handle the response
-	data, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return BlocklistGET{}, err
-	}
-	var blg BlocklistGET
-	json.Unmarshal(data, &blg)
-	return blg, nil
 }

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -281,7 +281,7 @@ func testHandleBlocklistGET(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// fetch the blocklist and assert it continas our blocked hash
+	// fetch the blocklist and assert it contains our blocked hash
 	bl, err = fetchBlocklist()
 	if err != nil {
 		t.Fatal(err)

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -235,7 +235,7 @@ func testHandleBlocklistGET(t *testing.T) {
 	apiTester := newAPITester(api)
 
 	// fetch the blocklist and assert it is empty
-	bl, err := apiTester.blocklistGET(api, nil, nil, nil)
+	bl, err := apiTester.blocklistGET(nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func testHandleBlocklistGET(t *testing.T) {
 	}
 
 	// assert base case
-	bl, err = apiTester.blocklistGET(api, nil, nil, nil)
+	bl, err = apiTester.blocklistGET(nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func testHandleBlocklistGET(t *testing.T) {
 
 	// assert limit of 1
 	limit := 1
-	bl, err = apiTester.blocklistGET(api, nil, nil, &limit)
+	bl, err = apiTester.blocklistGET(nil, nil, &limit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +298,7 @@ func testHandleBlocklistGET(t *testing.T) {
 
 	// assert offset of 1
 	offset := 1
-	bl, err = apiTester.blocklistGET(api, nil, &offset, nil)
+	bl, err = apiTester.blocklistGET(nil, &offset, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func testHandleBlocklistGET(t *testing.T) {
 
 	// assert sort
 	sort := "desc"
-	bl, err = apiTester.blocklistGET(api, &sort, nil, nil)
+	bl, err = apiTester.blocklistGET(&sort, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ func testHandleBlocklistGET(t *testing.T) {
 	hasmore := true
 	var entries []BlockedHash
 	for hasmore {
-		bl, err = apiTester.blocklistGET(api, nil, &offset, &limit)
+		bl, err = apiTester.blocklistGET(nil, &offset, &limit)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/routes.go
+++ b/api/routes.go
@@ -27,6 +27,7 @@ var (
 // buildHTTPRoutes registers all HTTP routes and their handlers.
 func (api *API) buildHTTPRoutes() {
 	api.staticRouter.GET("/health", api.healthGET)
+	api.staticRouter.GET("/blocklist", api.blocklistGET)
 	api.staticRouter.POST("/block", api.blockPOST)
 	api.staticRouter.GET("/powblock", api.blockWithPoWGET)
 	api.staticRouter.POST("/powblock", api.blockWithPoWPOST)

--- a/database/database.go
+++ b/database/database.go
@@ -156,7 +156,7 @@ func NewCustomDB(ctx context.Context, uri string, dbName string, creds options.C
 
 // BlockedHashes returns an array of blocked hashes.
 func (db *DB) BlockedHashes() ([]BlockedSkylink, error) {
-	return db.find(db.ctx, bson.M{"failed": bson.M{"$ne": true}})
+	return db.find(db.ctx, bson.M{"invalid": bson.M{"$ne": true}})
 }
 
 // Close disconnects the db.

--- a/database/database.go
+++ b/database/database.go
@@ -154,9 +154,26 @@ func NewCustomDB(ctx context.Context, uri string, dbName string, creds options.C
 	return cdb, nil
 }
 
-// BlockedHashes returns an array of blocked hashes.
-func (db *DB) BlockedHashes() ([]BlockedSkylink, error) {
-	return db.find(db.ctx, bson.M{"invalid": bson.M{"$ne": true}})
+// BlockedHashes allows to pass a skip and limit parameter and returns an array
+// of blocked hashes alongside a boolean that indicates whether there's more
+// documents after the current 'page'.
+func (db *DB) BlockedHashes(sort, skip, limit int) ([]BlockedSkylink, bool, error) {
+	// configure the options
+	opts := options.Find()
+	opts.SetSkip(int64(skip))
+	opts.SetLimit(int64(limit + 1))
+	opts.SetSort(bson.D{{"timestamp_added", sort}})
+
+	// fetch the documents
+	docs, err := db.find(db.ctx, bson.M{"invalid": bson.M{"$ne": true}}, opts)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(docs) > int(limit) {
+		return docs[:limit], true, nil
+	}
+	return docs, false, nil
 }
 
 // Close disconnects the db.

--- a/database/database.go
+++ b/database/database.go
@@ -170,6 +170,9 @@ func (db *DB) BlockedHashes(sort, skip, limit int) ([]BlockedSkylink, bool, erro
 		return nil, false, err
 	}
 
+	// we have done the find with "limit+1" because that allows us to return
+	// whether there are "more" documents after the given offset, we however do
+	// not want to return this document, but instead return 'true' if it existed
 	if len(docs) > int(limit) {
 		return docs[:limit], true, nil
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -154,6 +154,11 @@ func NewCustomDB(ctx context.Context, uri string, dbName string, creds options.C
 	return cdb, nil
 }
 
+// BlockedHashes returns an array of blocked hashes.
+func (db *DB) BlockedHashes() ([]BlockedSkylink, error) {
+	return db.find(db.ctx, bson.M{"failed": bson.M{"$ne": true}})
+}
+
 // Close disconnects the db.
 func (db *DB) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PRs adds a route that we need for the syncing feature. It exposes an endpoint `GET /blocklist` that returns blocked hashes and their tags. The syncer will fetch those from friendly portals and merge them with its own blocker database. This is quite a heavy database action and the response should be cached, but in order for it to be consistent with other cached responses we'll do this through nginx configuration rather than caching the response in memory.

The route takes some query string params: `sort`, `offset` and `limit`. It always sorts on `timestamp_added` but the caller can decide whether it's returned in ascending or descending fashion. Allowing to fetch "the latest" additions, which can be used to improve performance and avoid unnecessary calls.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A