### PR TITLE
Remove Compat Code

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"gitlab.com/NebulousLabs/errors"
-	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -137,19 +136,6 @@ func NewCustomDB(ctx context.Context, uri string, dbName string, creds options.C
 		staticSkylinks:  db.Collection(collSkylinks),
 		staticLogger:    logger,
 	}
-
-	// Run compat code
-	err = cdb.compatTransformSkylinkToHash(dbCtx)
-	if err != nil {
-		// We do not error out if we failed to run this compat code. We log it
-		// as a critical, but this should not prevent the blocker from running.
-		logger.Errorf(`[CRITICAL] failed to successfully run 'compatTransformSkylinkToHash', err: %v`, err)
-	}
-
-	// TODO: once the above compat code ran on the database, and the code was
-	// converted to handle hashes and not skylinks, new compat code has to be
-	// written to remove the index on 'skylink' and drop the field from all
-	// documents in our database
 
 	return cdb, nil
 }
@@ -339,73 +325,6 @@ func (db *DB) SetLatestBlockTimestamp(t time.Time) error {
 	return nil
 }
 
-// compatTransformSkylinkToHash is some compat code that transforms skylinks in
-// the database to hashes. Skylinks should not be persisted in their plain form
-// in the database.
-func (db *DB) compatTransformSkylinkToHash(ctx context.Context) error {
-	collSkylinks := db.staticDB.Collection(collSkylinks)
-
-	// define a filter that matches documents with skylink and no hash
-	filter := bson.D{{"$and", []interface{}{
-		bson.D{{"skylink", bson.M{"$exists": true}}},
-		bson.D{{"$or", []interface{}{
-			bson.D{{"hash", nil}},
-			bson.D{{"hash", bson.M{"$exists": false}}},
-			bson.D{{"hash", Hash{}}},
-		}}},
-	}}}
-
-	// find all documents where the skyink has to be transformed to a hash
-	docs, err := db.find(ctx, filter)
-	if err != nil {
-		return err
-	}
-
-	// return if no docs need to be transformed
-	if len(docs) == 0 {
-		return nil
-	}
-
-	// range over the documents and try to set the hash property on each one
-	for _, doc := range docs {
-		var sl skymodules.Skylink
-		err := sl.LoadString(doc.Skylink)
-		if err != nil {
-			// should be impossible
-			db.staticLogger.Errorf("failed to decode Skylink '%v'", doc.Skylink)
-			continue
-		}
-
-		// sanity check the skylink is not a v2 skylink, we can't update that
-		// document because it is illegal to call 'MerkleRoot' on a v2 skylink,
-		// the database should not contain v2 skylinks in the Skylink field
-		if sl.IsSkylinkV2() {
-			db.staticLogger.Errorf("failed to convert document with Skylink '%v', which is a v2 skylink", doc.Skylink)
-			continue
-		}
-
-		// define a filter that matches this precise document, ensuring the hash
-		// is unset, seeing as this code might be running concurrently, it might
-		// have been updated by another process in the mean time
-		filter = bson.D{{"$and", []interface{}{
-			bson.D{{"_id", doc.ID}},
-			bson.D{{"$or", []interface{}{
-				bson.D{{"hash", nil}},
-				bson.D{{"hash", bson.M{"$exists": false}}},
-				bson.D{{"hash", Hash{}}},
-			}}},
-		}}}
-		value := bson.M{"$set": bson.M{"hash": NewHash(sl)}}
-		_, err = collSkylinks.UpdateOne(ctx, filter, value)
-		if err != nil {
-			db.staticLogger.Errorf("failed to update hash of document with ID '%v', err %v", doc.ID, err)
-			continue
-		}
-	}
-
-	return nil
-}
-
 // find wraps the `Find` function on the Skylinks collection and returns an
 // array of decoded blocked skylink objects
 func (db *DB) find(ctx context.Context, filter interface{},
@@ -492,14 +411,9 @@ func ensureDBSchema(ctx context.Context, db *mongo.Database, log *logrus.Logger)
 			},
 		},
 		collSkylinks: {
-			// TODO: the schema should be extended here to have a unique index
-			// on the 'hash' field, this can be done safely if the compat code
-			// has executed and the blocker has been running on hashes for a
-			// while, at that time the skylink index should be dropped and
-			// prevented from being set in the first place
 			{
-				Keys:    bson.D{{"skylink", 1}},
-				Options: options.Index().SetName("skylink").SetUnique(true),
+				Keys:    bson.D{{"hash", 1}},
+				Options: options.Index().SetName("hash").SetUnique(true),
 			},
 			{
 				Keys:    bson.D{{"timestamp_added", 1}},

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -66,10 +66,6 @@ func TestDatabase(t *testing.T) {
 			name: "MarkAsFailed",
 			test: testMarkAsFailed,
 		},
-		{
-			name: "compatTransformSkylinkToHash",
-			test: testCompatTransformSkylinkToHash,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, test.test)
@@ -349,122 +345,6 @@ func testMarkAsFailed(t *testing.T) {
 	}
 
 	// no need to mark them as succeeded, the other unit test covers that
-}
-
-// testCompatTransformSkylinkToHash is a unit test that verifies the correct
-// execution of the 'compatTransformSkylinkToHash' method on the database.
-func testCompatTransformSkylinkToHash(t *testing.T) {
-	// create context
-	ctx, cancel := context.WithTimeout(context.Background(), MongoDefaultTimeout)
-	defer cancel()
-
-	// create test database
-	db := newTestDB(ctx, t.Name())
-	defer db.Close()
-
-	// define a helper function to count the number of documents that the compat
-	// code should run on
-	countOldDocs := func() int {
-		// find all documents where the skyink has to be transformed to a hash
-		docs, err := db.find(ctx, bson.D{{"$and", []interface{}{
-			bson.D{{"skylink", bson.M{"$exists": true}}},
-			bson.D{{"$or", []interface{}{
-				bson.D{{"hash", nil}},
-				bson.D{{"hash", bson.M{"$exists": false}}},
-				bson.D{{"hash", Hash{}}},
-			}}},
-		}}})
-		if err != nil {
-			t.Fatal(err)
-		}
-		return len(docs)
-	}
-
-	// assert the number of 'old' docs is 0
-	numOld := countOldDocs()
-	if numOld != 0 {
-		t.Fatalf("unexpected amount of docs, %v != 0", numOld)
-	}
-
-	// run the compat code on an empty database
-	err := db.compatTransformSkylinkToHash(ctx)
-	if err != nil {
-		t.Fatal("unexpected error", err)
-	}
-
-	// prepare 3 skylinks
-	sl1 := skylinkFromString("BAAWi3ou51qCH24Im0ESS-5_gKg60qGIYtta-ryrl1kBnQ")
-	sl2 := skylinkFromString("IABst6HgaJ0PIBMtmQ2qgH_wQlFg4bNnwAhff7DmJP6oyg")
-	sl3 := skylinkFromString("IABXaRBvjDTB3RizX3RfwdCoxt2Tff1buEXhlO7b9Unn8g")
-
-	// insert two documents with a skylink but no hash (like it was originally)
-	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{
-		Skylink:        sl1.String(),
-		Reporter:       Reporter{},
-		Tags:           []string{"tag_1"},
-		TimestampAdded: time.Now().UTC(),
-	})
-	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{
-		Skylink:        sl2.String(),
-		Reporter:       Reporter{},
-		Tags:           []string{"tag_1"},
-		TimestampAdded: time.Now().Add(time.Minute).UTC(),
-	})
-
-	// insert one documents with a skylink and a hash
-	db.staticSkylinks.InsertOne(ctx, BlockedSkylink{
-		Skylink:        sl3.String(),
-		Hash:           NewHash(sl3),
-		Reporter:       Reporter{},
-		Tags:           []string{"tag_1"},
-		TimestampAdded: time.Now().Add(time.Hour).UTC(),
-	})
-
-	// assert the number of 'old' docs is 2
-	numOld = countOldDocs()
-	if numOld != 2 {
-		t.Fatalf("unexpected amount of docs, %v != 2", numOld)
-	}
-
-	// run the compat code again
-	err = db.compatTransformSkylinkToHash(ctx)
-	if err != nil {
-		t.Fatal("unexpected error", err)
-	}
-
-	// find all skylink documents, in order
-	opts := options.Find()
-	opts.SetSort(bson.D{{"timestamp_added", 1}})
-	skylinks, err := db.find(ctx, bson.D{}, opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(skylinks) != 3 {
-		t.Fatalf("unexpected amount of docs, %v != 3", len(skylinks))
-	}
-
-	// assert the skylink and hash value for all documents
-	sl11 := skylinkFromString(skylinks[0].Skylink)
-	if sl11.String() != sl1.String() {
-		t.Fatal("unexpected skylink value")
-	}
-	if NewHash(sl11) != skylinks[0].Hash {
-		t.Fatal("unexpected hash value", NewHash(sl11), skylinks[0].Hash)
-	}
-	sl22 := skylinkFromString(skylinks[1].Skylink)
-	if sl22.String() != sl2.String() {
-		t.Fatal("unexpected skylink value")
-	}
-	if NewHash(sl22) != skylinks[1].Hash {
-		t.Fatal("unexpected hash value")
-	}
-	sl33 := skylinkFromString(skylinks[2].Skylink)
-	if sl33.String() != sl3.String() {
-		t.Fatal("unexpected skylink value")
-	}
-	if NewHash(sl33) != skylinks[2].Hash {
-		t.Fatal("unexpected hash value")
-	}
 }
 
 // define a helper function to decode a skylink as string into a skylink obj


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PR removes the compat code we had to convert all skylinks to hashes in the mongo documents. It also adds a unique index on the `hash` field, which we can do now since all documents contain a valid hash property and there's no duplicates, I checked.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A