### PR TITLE
Use Waitgroup

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -132,7 +132,7 @@ func (api *API) blocklistGET(w http.ResponseWriter, r *http.Request, _ httproute
 		return
 	}
 
-	blocked, more, err := api.staticDB.BlockedHashes(sort, offset, limit)
+	blocked, more, err := api.staticDB.BlockedHashes(r.Context(), sort, offset, limit)
 	if err != nil {
 		skyapi.WriteError(w, skyapi.Error{err.Error()}, http.StatusInternalServerError)
 		return

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -52,20 +52,17 @@ type (
 		// to block.
 		latestBlockTime time.Time
 
-		staticCtx       context.Context
 		staticDB        *database.DB
 		staticLogger    *logrus.Logger
 		staticMu        sync.Mutex
 		staticSkydAPI   skyd.API
+		staticStopChan  chan struct{}
 		staticWaitGroup sync.WaitGroup
 	}
 )
 
 // New returns a new Blocker with the given parameters.
-func New(ctx context.Context, skydAPI skyd.API, db *database.DB, logger *logrus.Logger) (*Blocker, error) {
-	if ctx == nil {
-		return nil, errors.New("no context provided")
-	}
+func New(skydAPI skyd.API, db *database.DB, logger *logrus.Logger) (*Blocker, error) {
 	if db == nil {
 		return nil, errors.New("no DB provided")
 	}
@@ -76,10 +73,10 @@ func New(ctx context.Context, skydAPI skyd.API, db *database.DB, logger *logrus.
 		return nil, errors.New("no Skyd API provided")
 	}
 	bl := &Blocker{
-		staticCtx:     ctx,
-		staticDB:      db,
-		staticLogger:  logger,
-		staticSkydAPI: skydAPI,
+		staticDB:       db,
+		staticLogger:   logger,
+		staticSkydAPI:  skydAPI,
+		staticStopChan: make(chan struct{}),
 	}
 	return bl, nil
 }
@@ -97,7 +94,7 @@ func (bl *Blocker) BlockHashes(hashes []database.Hash) (int, int, error) {
 	for start < len(hashes) {
 		// check whether we need to escape
 		select {
-		case <-bl.staticCtx.Done():
+		case <-bl.staticStopChan:
 			return numBlocked, numInvalid, nil
 		default:
 		}
@@ -115,7 +112,9 @@ func (bl *Blocker) BlockHashes(hashes []database.Hash) (int, int, error) {
 		// escape early because something is probably wrong
 		blocked, invalid, err := bl.staticSkydAPI.BlockHashes(batch)
 		if err != nil {
-			err = errors.Compose(err, bl.staticDB.MarkFailed(batch))
+			ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+			defer cancel()
+			err = errors.Compose(err, bl.staticDB.MarkFailed(ctx, batch))
 			return numBlocked, numInvalid, err
 		}
 
@@ -123,12 +122,17 @@ func (bl *Blocker) BlockHashes(hashes []database.Hash) (int, int, error) {
 		numBlocked += len(blocked)
 		numInvalid += len(invalid)
 
+		// create a context
+		ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+
 		// update the documents
-		err1 := bl.staticDB.MarkSucceeded(blocked)
-		err2 := bl.staticDB.MarkInvalid(invalid)
+		err1 := bl.staticDB.MarkSucceeded(ctx, blocked)
+		err2 := bl.staticDB.MarkInvalid(ctx, invalid)
 		if err := errors.Compose(err1, err2); err != nil {
+			cancel()
 			return numBlocked, numInvalid, err
 		}
+		cancel()
 
 		// update start
 		start = end
@@ -167,17 +171,26 @@ func (bl *Blocker) Start() error {
 
 // Stop waits for the blocker's waitgroup and times out after one minute.
 func (bl *Blocker) Stop() error {
+	// check whether the blocker was started
+	bl.staticMu.Lock()
+	if !bl.started {
+		bl.staticMu.Unlock()
+		return errors.New("blocker not started")
+	}
+	bl.started = false
+	bl.staticMu.Unlock()
+
+	// stop the blocker by closing the stop channel
+	close(bl.staticStopChan)
+
+	// wait for the waitgroup, timeout and signal unclean shutdown after 1m
 	c := make(chan struct{})
 	go func() {
 		defer close(c)
 		bl.staticWaitGroup.Wait()
 	}()
-
 	select {
 	case <-c:
-		bl.staticMu.Lock()
-		defer bl.staticMu.Unlock()
-		bl.started = false
 		return nil
 	case <-time.After(time.Minute):
 		return errors.New("unclean blocker shutdown")
@@ -198,7 +211,7 @@ func (bl *Blocker) threadedBlockLoop() {
 		}
 
 		select {
-		case <-bl.staticCtx.Done():
+		case <-bl.staticStopChan:
 			return
 		case <-time.After(blockInterval):
 		}
@@ -219,7 +232,7 @@ func (bl *Blocker) threadedRetryLoop() {
 		}
 
 		select {
-		case <-bl.staticCtx.Done():
+		case <-bl.staticStopChan:
 			return
 		case <-time.After(retryInterval):
 		}
@@ -231,8 +244,12 @@ func (bl *Blocker) managedBlock() error {
 	now := time.Now().UTC()
 	from := bl.managedLatestBlockTime()
 
+	// Create a context
+	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+	defer cancel()
+
 	// Fetch hashes to block
-	hashes, err := bl.staticDB.HashesToBlock(from)
+	hashes, err := bl.staticDB.HashesToBlock(ctx, from)
 	if err != nil {
 		return err
 	}
@@ -267,8 +284,12 @@ func (bl *Blocker) managedLatestBlockTime() time.Time {
 // managedRetryHashes fetches all blocked skylinks that failed to get blocked
 // the first time and retries them.
 func (bl *Blocker) managedRetryHashes() error {
+	// Create a context
+	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+	defer cancel()
+
 	// Fetch hashes to retry
-	hashes, err := bl.staticDB.HashesToRetry()
+	hashes, err := bl.staticDB.HashesToRetry(ctx)
 	if err != nil {
 		return err
 	}

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -16,6 +16,11 @@ const (
 	// blockBatchSize is the max number of (skylink) hashes to be sent for
 	// blocking simultaneously.
 	blockBatchSize = 100
+
+	// stopTimeoutDuration is the amount of time we wait when stop is called
+	// before cancelling out and returning with an error indicating an unclean
+	// shutdown.
+	stopTimeoutDuration = time.Minute
 )
 
 var (
@@ -192,7 +197,7 @@ func (bl *Blocker) Stop() error {
 	select {
 	case <-c:
 		return nil
-	case <-time.After(time.Minute):
+	case <-time.After(stopTimeoutDuration):
 		return errors.New("unclean blocker shutdown")
 	}
 }

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -152,7 +152,7 @@ func newTestBlocker(ctx context.Context, dbName string, api skyd.API) (*Blocker,
 	}
 
 	// create the blocker
-	blocker, err := New(ctx, api, db, logger)
+	blocker, err := New(api, db, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -73,15 +73,24 @@ func testBlockHashes(t *testing.T) {
 	api := &mockSkyd{}
 
 	// create the blocker
-	blocker, err := newTestBlocker("BlockHashes", api)
+	ctx, cancel := context.WithCancel(context.Background())
+	blocker, err := newTestBlocker(ctx, "BlockHashes", api)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// defer a db close
+	// start the syncer
+	err = blocker.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// defer a call to stops
 	defer func() {
-		if err := blocker.staticDB.Close(); err != nil {
-			t.Error(err)
+		cancel()
+		err := blocker.Stop()
+		if err != nil {
+			t.Fatal(err)
 		}
 	}()
 
@@ -128,13 +137,13 @@ func testBlockHashes(t *testing.T) {
 }
 
 // newTestBlocker returns a new blocker instance
-func newTestBlocker(dbName string, api skyd.API) (*Blocker, error) {
+func newTestBlocker(ctx context.Context, dbName string, api skyd.API) (*Blocker, error) {
 	// create a nil logger
 	logger := logrus.New()
 	logger.Out = ioutil.Discard
 
 	// create database
-	db, err := database.NewCustomDB(context.Background(), "mongodb://localhost:37017", dbName, options.Credential{
+	db, err := database.NewCustomDB(ctx, "mongodb://localhost:37017", dbName, options.Credential{
 		Username: "admin",
 		Password: "aO4tV5tC1oU3oQ7u",
 	}, logger)
@@ -143,7 +152,7 @@ func newTestBlocker(dbName string, api skyd.API) (*Blocker, error) {
 	}
 
 	// create the blocker
-	blocker, err := New(context.Background(), api, db, logger)
+	blocker, err := New(ctx, api, db, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/database/skylink_test.go
+++ b/database/skylink_test.go
@@ -26,8 +26,8 @@ func TestHashMarhsaling(t *testing.T) {
 	defer cancel()
 
 	// create test database
-	db := newTestDB(ctx, t.Name())
-	defer db.Close()
+	db := newTestDB(t.Name())
+	defer db.Close(ctx)
 
 	// create test collection and purge it
 	coll := db.staticDB.Collection(t.Name())

--- a/main.go
+++ b/main.go
@@ -66,11 +66,11 @@ func main() {
 
 	// Create a connection to the database
 	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+	defer cancel()
 	db, err := database.New(ctx, uri, dbCreds, logger)
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to connect to the db"))
 	}
-	cancel()
 
 	// Blocker env vars.
 	skydPort := defaultSkydPort
@@ -167,9 +167,9 @@ func main() {
 	}
 
 	// Close the database connection
-	ctx, cancel = context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
-	defer cancel()
-	err = db.Close(ctx)
+	dbCtx, dbCancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
+	defer dbCancel()
+	err = db.Close(dbCtx)
 	if err != nil {
 		log.Fatal("Failed to disconnect from the database, err: ", err)
 	}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -13,6 +13,13 @@ import (
 	"go.sia.tech/siad/build"
 )
 
+const (
+	// stopTimeoutDuration is the amount of time we wait when stop is called
+	// before cancelling out and returning with an error indicating an unclean
+	// shutdown.
+	stopTimeoutDuration = time.Minute
+)
+
 var (
 	// syncInterval defines the amount of time between syncs of external
 	// portal's blocklists, which can be defined in the environment using the
@@ -120,7 +127,7 @@ func (s *Syncer) Stop() error {
 	select {
 	case <-c:
 		return nil
-	case <-time.After(time.Minute):
+	case <-time.After(stopTimeoutDuration):
 		return errors.New("unclean syncer shutdown")
 	}
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Small F/U PR that introduces a waitgroup to both the blocker and `syncer` modules. When an interrupt signal gets caught,
we give both modules some time to finalize what they're doing and try and shut down cleanly.

Edit: I ended up refactoring the use of contexts a bit. The context on the `blocker` and `syncer` were pretty meaningless, so I removed those and replaced them with a stop chan, which gets closed when `Stop` gets called. I also allow passing in a context to all DB methods now.


## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
Closes #28 