### PR TITLE
Block through skyd instead of nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ This service depends on the following environment variables:
 * `API_HOST`, defaults to `sia`
 * `API_PORT`, defaults to `9980`
 * `SIA_API_PASSWORD`
-* `NGINX_HOST`, defaults to `10.10.10.30`
-* `NGINX_PORT`, defaults to `8000`
 * `SKYNET_DB_HOST`
 * `SKYNET_DB_PORT`
 * `SKYNET_DB_USER`

--- a/main.go
+++ b/main.go
@@ -27,14 +27,6 @@ const (
 	// defaultSkydPort is where we connect to skyd unless overwritten by
 	// "API_PORT" environment variables.
 	defaultSkydPort = 9980
-
-	// defaultNginxHost is where we connect to nginx unless overwritten by
-	// "NGINX_HOST" environment variables.
-	defaultNginxHost = "10.10.10.30"
-
-	// defaultNginxPort is where we connect to nginx unless overwritten by
-	// "NGINX_PORT" environment variables.
-	defaultNginxPort = 8000
 )
 
 func main() {
@@ -79,15 +71,6 @@ func main() {
 	if skydHostEnv := os.Getenv("API_HOST"); skydHostEnv != "" {
 		skydHost = skydHostEnv
 	}
-	nginxPort := defaultNginxPort
-	nginxPortEnv, err := strconv.Atoi(os.Getenv("NGINX_PORT"))
-	if err == nil && nginxPortEnv > 0 {
-		nginxPort = nginxPortEnv
-	}
-	nginxHost := defaultNginxHost
-	if nginxHostEnv := os.Getenv("NGINX_HOST"); nginxHostEnv != "" {
-		nginxHost = nginxHostEnv
-	}
 	skydAPIPassword := os.Getenv("SIA_API_PASSWORD")
 	if skydAPIPassword == "" {
 		log.Fatal(errors.New("SIA_API_PASSWORD is empty, exiting"))
@@ -102,7 +85,7 @@ func main() {
 	}
 
 	// Create a skyd API.
-	skydAPI, err := skyd.NewAPI(nginxHost, nginxPort, skydHost, skydAPIPassword, skydPort, db, logger)
+	skydAPI, err := skyd.NewAPI(skydHost, skydAPIPassword, skydPort, db, logger)
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to instantiate Skyd API"))
 	}

--- a/skyd/api.go
+++ b/skyd/api.go
@@ -37,9 +37,6 @@ type (
 	// api is a helper struct that exposes some methods that allow making skyd
 	// API calls used by both the API and the blocker
 	api struct {
-		staticNginxHost string
-		staticNginxPort int
-
 		staticSkydHost        string
 		staticSkydPort        int
 		staticSkydAPIPassword string
@@ -82,7 +79,7 @@ func (br *blockResponse) InvalidHashes() ([]database.Hash, error) {
 }
 
 // NewAPI creates a new API instance.
-func NewAPI(nginxHost string, nginxPort int, skydHost, skydPassword string, skydPort int, db *database.DB, logger *logrus.Logger) (API, error) {
+func NewAPI(skydHost, skydPassword string, skydPort int, db *database.DB, logger *logrus.Logger) (API, error) {
 	if db == nil {
 		return nil, errors.New("no DB provided")
 	}
@@ -91,9 +88,6 @@ func NewAPI(nginxHost string, nginxPort int, skydHost, skydPassword string, skyd
 	}
 
 	return &api{
-		staticNginxHost: nginxHost,
-		staticNginxPort: nginxPort,
-
 		staticSkydHost:        skydHost,
 		staticSkydPort:        skydPort,
 		staticSkydAPIPassword: skydPassword,
@@ -126,7 +120,7 @@ func (api *api) BlockHashes(hashes []database.Hash) ([]database.Hash, []database
 	}
 
 	// execute the request
-	url := fmt.Sprintf("http://%s:%d/skynet/blocklist?timeout=%s", api.staticNginxHost, api.staticNginxPort, skydTimeout)
+	url := fmt.Sprintf("http://%s:%d/skynet/blocklist?timeout=%s", api.staticSkydHost, api.staticSkydPort, skydTimeout)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, nil, errors.AddContext(err, "failed to build request to skyd")


### PR DESCRIPTION
# PULL REQUEST

## Overview

[This PR](https://github.com/SkynetLabs/skynet-webportal/pull/1869) removes all caching in nginx, therefor we should also update the blocker service and remove all notions of where Nginx lives and just call skyd directly. [We should also update the portal documentation.](https://app.gitbook.com/o/-MNU7OgHAjte01kixOVD/s/-MUK_Mw0gD4rwZuDvBpi/~/diff/~/changes/0RZ32cXqlTWGfqAARVXI/webportal-management/handling-abuse-requests/abuse-handling-modules)

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A