### PR TITLE
[MINOR] Rename Client to SkydClient

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,11 +16,11 @@ type API struct {
 	staticDB         *database.DB
 	staticLogger     *logrus.Logger
 	staticRouter     *httprouter.Router
-	staticSkydClient *Client
+	staticSkydClient *SkydClient
 }
 
 // New creates a new API instance.
-func New(skydClient *Client, db *database.DB, logger *logrus.Logger) (*API, error) {
+func New(skydClient *SkydClient, db *database.DB, logger *logrus.Logger) (*API, error) {
 	if db == nil {
 		return nil, errors.New("no DB provided")
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -25,7 +25,7 @@ func newAPITester(api *API) *apiTester {
 }
 
 // newTestAPI returns a new API instance
-func newTestAPI(dbName string, client *Client) (*API, error) {
+func newTestAPI(dbName string, client *SkydClient) (*API, error) {
 	// create a nil logger
 	logger := logrus.New()
 	logger.Out = ioutil.Discard

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -16,8 +16,9 @@ func mockPortalBlocklistResponse(w http.ResponseWriter, r *http.Request) {
 	skyapi.WriteJSON(w, blg)
 }
 
-// TestClient contains subtests for the client and makes up the testing suite
-func TestClient(t *testing.T) {
+// TestSkydClient contains subtests for the client and makes up the testing
+// suite
+func TestSkydClient(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -45,7 +46,7 @@ func TestClient(t *testing.T) {
 
 // testBlocklistGET ensures the client can fetch the blocklist
 func testBlocklistGET(t *testing.T, s *httptest.Server) {
-	c := NewClient(s.URL)
+	c := NewSkydClient(s.URL, "")
 	bl, err := c.BlocklistGET(0)
 	if err != nil {
 		t.Fatal(err)

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -107,7 +107,7 @@ func TestHandlers(t *testing.T) {
 // routes and contains all shared logic.
 func testHandleBlockRequest(t *testing.T, server *httptest.Server) {
 	// create a client that connects to our server
-	client := NewClient(server.URL)
+	client := NewSkydClient(server.URL, "")
 
 	// create a context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)
@@ -230,7 +230,7 @@ func testHandleBlockRequest(t *testing.T, server *httptest.Server) {
 // testHandleBlocklistGET verifies the GET /blocklist endpoint
 func testHandleBlocklistGET(t *testing.T, server *httptest.Server) {
 	// create a client that connects to our server
-	client := NewClient(server.URL)
+	client := NewSkydClient(server.URL, "")
 
 	// create a context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), database.MongoDefaultTimeout)

--- a/blocker/blocker.go
+++ b/blocker/blocker.go
@@ -60,14 +60,14 @@ type (
 		staticDB         *database.DB
 		staticLogger     *logrus.Logger
 		staticMu         sync.Mutex
-		staticSkydClient *api.Client
+		staticSkydClient *api.SkydClient
 		staticStopChan   chan struct{}
 		staticWaitGroup  sync.WaitGroup
 	}
 )
 
 // New returns a new Blocker with the given parameters.
-func New(skydClient *api.Client, db *database.DB, logger *logrus.Logger) (*Blocker, error) {
+func New(skydClient *api.SkydClient, db *database.DB, logger *logrus.Logger) (*Blocker, error) {
 	if db == nil {
 		return nil, errors.New("no DB provided")
 	}

--- a/blocker/blocker_test.go
+++ b/blocker/blocker_test.go
@@ -68,7 +68,7 @@ func TestBlocker(t *testing.T) {
 // testBlockHashes is a unit test that covers the 'blockHashes' method.
 func testBlockHashes(t *testing.T, server *httptest.Server) {
 	// create a client that connects to our server
-	client := api.NewClient(server.URL)
+	client := api.NewSkydClient(server.URL, "")
 
 	// create the blocker
 	ctx, cancel := context.WithCancel(context.Background())
@@ -126,7 +126,7 @@ func testBlockHashes(t *testing.T, server *httptest.Server) {
 }
 
 // newTestBlocker returns a new blocker instance
-func newTestBlocker(ctx context.Context, dbName string, skydClient *api.Client) (*Blocker, error) {
+func newTestBlocker(ctx context.Context, dbName string, skydClient *api.SkydClient) (*Blocker, error) {
 	// create a nil logger
 	logger := logrus.New()
 	logger.Out = ioutil.Discard

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -88,14 +86,9 @@ func main() {
 		api.AccountsPort = aPort
 	}
 
-	// Build auth header
-	var headers http.Header
-	encoded := base64.StdEncoding.EncodeToString([]byte(":" + skydAPIPassword))
-	headers.Set("Authorization", fmt.Sprintf("Basic %s", encoded))
-
 	// Create a skyd client
 	skydUrl := fmt.Sprintf("http://%s:%d", skydHost, skydPort)
-	skydClient := api.NewSkydClient(skydUrl, headers)
+	skydClient := api.NewSkydClient(skydUrl, skydAPIPassword)
 	if !skydClient.DaemonReady() {
 		log.Fatal(errors.New("skyd down, exiting"))
 	}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -171,7 +171,7 @@ func (s *Syncer) managedSyncPortals() error {
 		logger.Infof("syncing blocklist for portal '%s'", portalURL)
 
 		// create a client and fetch the last synced hash
-		client := api.NewClient(portalURL)
+		client := api.NewSkydClient(portalURL, "")
 		lastSynced := s.managedLastSyncedHash(portalURL)
 		reporter := database.Reporter{Name: portalURL}
 


### PR DESCRIPTION
# PULL REQUEST

## Overview
Simple rename because `Client` was too generic. I originally wanted it to be generic but since we handle errors as errors coming from a Skyd portal it does make sense to make it a `SkydClient` instead.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
Closes #31 